### PR TITLE
Fix sample frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ description: "Samples to accompany the official Microsoft Blazor documentation."
 page_type: sample
 languages:
 - csharp
-- razor
+- cshtml
 name: "Blazor sample applications"
 products:
 - aspnet-core


### PR DESCRIPTION
Change `razor` to `cshtml` since razor is not in the list of languages for samples. This is causing an error that prevents listing in the Docs / Samples browser.