### PR TITLE
Center position of loading message

### DIFF
--- a/7.0/BlazorSample_WebAssembly/wwwroot/index.html
+++ b/7.0/BlazorSample_WebAssembly/wwwroot/index.html
@@ -14,7 +14,7 @@
 </head>
 
 <body>
-    <div id="app">Loading...</div>
+    <div id="app"><div class="d-flex vh-100 justify-content-center align-items-center">Loading...</div></div>
 
     <div id="blazor-error-ui">
         An unhandled error has occurred.


### PR DESCRIPTION
I think this is better default, and indirectly hint how this process can be customized. 
I also would like to submit this change to templates repo, because without that startup experience degraded. Given that current template is somewhat fully functional, I believe that small tidbit would be helpful for developers