### PR TITLE
Change hardcoded CSS filename to assembly name

### DIFF
--- a/7.0/BlazorServerEFCoreSample/Pages/_Host.cshtml
+++ b/7.0/BlazorServerEFCoreSample/Pages/_Host.cshtml
@@ -11,7 +11,7 @@
     <base href="~/" />
     <link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" />
     <link href="css/site.css" rel="stylesheet" />
-    <link href="BlazorServerEFCoreSample.styles.css" rel="stylesheet" />
+    <link href="@(typeof(App).Assembly.GetName().Name).styles.css" rel="stylesheet" />
     <link rel="icon" type="image/png" href="favicon.png"/>
     <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
 </head>


### PR DESCRIPTION
When someone wants to rename a project, linked CSS still has the old name, so it will not work. I propose changing a hardcoded project name to a calculated value.