### PR TITLE
Support for indexed bots so that they do not collect information abou…

### DIFF
--- a/3.1/BlazorSample_Server/Pages/_Host.cshtml
+++ b/3.1/BlazorSample_Server/Pages/_Host.cshtml
@@ -20,7 +20,7 @@
         <component type="typeof(App)" render-mode="ServerPrerendered" />
     </app>
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         <environment include="Staging,Production">
             An error has occurred. This application may no longer respond until reloaded.
         </environment>

--- a/3.1/BlazorSample_WebAssembly/wwwroot/index.html
+++ b/3.1/BlazorSample_WebAssembly/wwwroot/index.html
@@ -13,7 +13,7 @@
 <body>
     <app>Loading...</app>
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         An unhandled error has occurred.
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>

--- a/3.1/BlazorServerEFCoreSample/BlazorServerDbContextExample/Pages/_Host.cshtml
+++ b/3.1/BlazorServerEFCoreSample/BlazorServerDbContextExample/Pages/_Host.cshtml
@@ -21,7 +21,7 @@
         <component type="typeof(App)" render-mode="ServerPrerendered" />
     </app>
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         <environment include="Staging,Production">
             An error has occurred. This application may no longer respond until reloaded.
         </environment>

--- a/5.0/BlazorSample_Server/Pages/_Host.cshtml
+++ b/5.0/BlazorSample_Server/Pages/_Host.cshtml
@@ -20,7 +20,7 @@
 <body>
     <component type="typeof(App)" render-mode="ServerPrerendered" />
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         <environment include="Staging,Production">
             An error has occurred. This application may no longer respond until reloaded.
         </environment>

--- a/5.0/BlazorSample_WebAssembly/wwwroot/index.html
+++ b/5.0/BlazorSample_WebAssembly/wwwroot/index.html
@@ -15,7 +15,7 @@
 <body>
     <div id="app">Loading...</div>
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         An unhandled error has occurred.
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>

--- a/5.0/BlazorServerEFCoreSample/BlazorServerDbContextExample/Pages/_Host.cshtml
+++ b/5.0/BlazorServerEFCoreSample/BlazorServerDbContextExample/Pages/_Host.cshtml
@@ -21,7 +21,7 @@
         <component type="typeof(App)" render-mode="ServerPrerendered" />
     </app>
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         <environment include="Staging,Production">
             An error has occurred. This application may no longer respond until reloaded.
         </environment>

--- a/6.0/BlazorSample_Server/Pages/_Layout.cshtml
+++ b/6.0/BlazorSample_Server/Pages/_Layout.cshtml
@@ -17,7 +17,7 @@
 <body>
     @RenderBody()
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         <environment include="Staging,Production">
             An error has occurred. This application may no longer respond until reloaded.
         </environment>

--- a/6.0/BlazorSample_WebAssembly/wwwroot/index.html
+++ b/6.0/BlazorSample_WebAssembly/wwwroot/index.html
@@ -15,7 +15,7 @@
 <body>
     <div id="app">Loading...</div>
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         An unhandled error has occurred.
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>

--- a/6.0/BlazorServerEFCoreSample/BlazorServerDbContextExample/Pages/_Layout.cshtml
+++ b/6.0/BlazorServerEFCoreSample/BlazorServerDbContextExample/Pages/_Layout.cshtml
@@ -16,7 +16,7 @@
 <body>
     @RenderBody()
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         <environment include="Staging,Production">
             An error has occurred. This application may no longer respond until reloaded.
         </environment>

--- a/6.0/BlazorServerSignalRApp/Pages/_Layout.cshtml
+++ b/6.0/BlazorServerSignalRApp/Pages/_Layout.cshtml
@@ -16,7 +16,7 @@
 <body>
     @RenderBody()
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         <environment include="Staging,Production">
             An error has occurred. This application may no longer respond until reloaded.
         </environment>

--- a/6.0/BlazorWebAssemblyScopesLogger/wwwroot/index.html
+++ b/6.0/BlazorWebAssemblyScopesLogger/wwwroot/index.html
@@ -14,7 +14,7 @@
 <body>
     <div id="app">Loading...</div>
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         An unhandled error has occurred.
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>

--- a/6.0/BlazorWebAssemblySignalRApp/Client/wwwroot/index.html
+++ b/6.0/BlazorWebAssemblySignalRApp/Client/wwwroot/index.html
@@ -14,7 +14,7 @@
 <body>
     <div id="app">Loading...</div>
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         An unhandled error has occurred.
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>

--- a/7.0/BlazorSample_Server/Pages/_Host.cshtml
+++ b/7.0/BlazorSample_Server/Pages/_Host.cshtml
@@ -19,7 +19,7 @@
 <body>
     <component type="typeof(App)" render-mode="ServerPrerendered" />
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         <environment include="Staging,Production">
             An error has occurred. This application may no longer respond until reloaded.
         </environment>

--- a/7.0/BlazorSample_WebAssembly/wwwroot/index.html
+++ b/7.0/BlazorSample_WebAssembly/wwwroot/index.html
@@ -16,7 +16,7 @@
 <body>
     <div id="app">Loading...</div>
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         An unhandled error has occurred.
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>

--- a/7.0/BlazorServerEFCoreSample/Pages/_Host.cshtml
+++ b/7.0/BlazorServerEFCoreSample/Pages/_Host.cshtml
@@ -18,7 +18,7 @@
 <body>
     <component type="typeof(App)" render-mode="ServerPrerendered" />
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         <environment include="Staging,Production">
             An error has occurred. This application may no longer respond until reloaded.
         </environment>

--- a/7.0/BlazorServerSignalRApp/Pages/_Host.cshtml
+++ b/7.0/BlazorServerSignalRApp/Pages/_Host.cshtml
@@ -18,7 +18,7 @@
 <body>
     <component type="typeof(App)" render-mode="ServerPrerendered" />
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         <environment include="Staging,Production">
             An error has occurred. This application may no longer respond until reloaded.
         </environment>

--- a/7.0/BlazorWebAssemblyScopesLogger/wwwroot/index.html
+++ b/7.0/BlazorWebAssemblyScopesLogger/wwwroot/index.html
@@ -15,7 +15,7 @@
 <body>
     <div id="app">Loading...</div>
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         An unhandled error has occurred.
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>

--- a/7.0/BlazorWebAssemblySignalRApp/Client/wwwroot/index.html
+++ b/7.0/BlazorWebAssemblySignalRApp/Client/wwwroot/index.html
@@ -15,7 +15,7 @@
 <body>
     <div id="app">Loading...</div>
 
-    <div id="blazor-error-ui">
+    <div id="blazor-error-ui" data-nosnippet>
         An unhandled error has occurred.
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>


### PR DESCRIPTION
Indexing bots in some cases may download content that we do not want. This is blazor error information.
We can set the ``data-nosnippet`` tag to prevent this.

https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#data-nosnippet-attr

The problem is also described here:
https://github.com/dotnet/aspnetcore/issues/46289