### PR TITLE
Remove dotnet-core product metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ name: "Blazor sample applications"
 products:
 - aspnet-core
 - blazor
-- dotnet-core
 urlFragment: "blazor-samples"
 ---
 # Samples to accompany the official Microsoft Blazor documentation


### PR DESCRIPTION
.NET Core is not the main technology focus for these samples. Also we'd like to remove that label from the site experience.

Contributes to https://github.com/dotnet/docs/issues/35970