### PR TITLE
Use @rendermode InteractiveServer & Antiforgery in BlazorWebAppEFCore

### DIFF
--- a/8.0/BlazorWebAppEFCore/Components/Pages/AddContact.razor
+++ b/8.0/BlazorWebAppEFCore/Components/Pages/AddContact.razor
@@ -1,5 +1,5 @@
 ﻿@page "/add"
-@attribute [RenderModeServer]
+@rendermode RenderMode.InteractiveServer
 @using BlazorWebAppEFCore.Grid
 @inject IDbContextFactory<ContactContext> DbFactory
 @inject NavigationManager Navigation

--- a/8.0/BlazorWebAppEFCore/Components/Pages/AddContact.razor
+++ b/8.0/BlazorWebAppEFCore/Components/Pages/AddContact.razor
@@ -1,5 +1,5 @@
 ﻿@page "/add"
-@rendermode RenderMode.InteractiveServer
+@rendermode InteractiveServer
 @using BlazorWebAppEFCore.Grid
 @inject IDbContextFactory<ContactContext> DbFactory
 @inject NavigationManager Navigation

--- a/8.0/BlazorWebAppEFCore/Components/Pages/EditContact.razor
+++ b/8.0/BlazorWebAppEFCore/Components/Pages/EditContact.razor
@@ -1,5 +1,5 @@
 ﻿@page "/edit/{ContactId:int}"
-@rendermode RenderMode.InteractiveServer
+@rendermode InteractiveServer
 @using Microsoft.EntityFrameworkCore;
 @using BlazorWebAppEFCore.Grid
 @using BlazorWebAppEFCore.Data

--- a/8.0/BlazorWebAppEFCore/Components/Pages/EditContact.razor
+++ b/8.0/BlazorWebAppEFCore/Components/Pages/EditContact.razor
@@ -1,5 +1,5 @@
 ﻿@page "/edit/{ContactId:int}"
-@attribute [RenderModeServer]
+@rendermode RenderMode.InteractiveServer
 @using Microsoft.EntityFrameworkCore;
 @using BlazorWebAppEFCore.Grid
 @using BlazorWebAppEFCore.Data

--- a/8.0/BlazorWebAppEFCore/Components/Pages/Home.razor
+++ b/8.0/BlazorWebAppEFCore/Components/Pages/Home.razor
@@ -1,6 +1,6 @@
 ﻿@page "/"
 @page "/{Page:int}"
-@rendermode RenderMode.InteractiveServer
+@rendermode InteractiveServer
 @using BlazorWebAppEFCore.Grid
 @using Microsoft.EntityFrameworkCore
 @inject IContactFilters Filters

--- a/8.0/BlazorWebAppEFCore/Components/Pages/Home.razor
+++ b/8.0/BlazorWebAppEFCore/Components/Pages/Home.razor
@@ -1,6 +1,6 @@
 ﻿@page "/"
 @page "/{Page:int}"
-@attribute [RenderModeServer]
+@rendermode RenderMode.InteractiveServer
 @using BlazorWebAppEFCore.Grid
 @using Microsoft.EntityFrameworkCore
 @inject IContactFilters Filters

--- a/8.0/BlazorWebAppEFCore/Components/Pages/ViewContact.razor
+++ b/8.0/BlazorWebAppEFCore/Components/Pages/ViewContact.razor
@@ -1,5 +1,5 @@
 ﻿@page "/View/{ContactId:int}"
-@rendermode RenderMode.InteractiveServer
+@rendermode InteractiveServer
 @using BlazorWebAppEFCore.Grid
 @using BlazorWebAppEFCore.Data
 @using Microsoft.EntityFrameworkCore

--- a/8.0/BlazorWebAppEFCore/Components/Pages/ViewContact.razor
+++ b/8.0/BlazorWebAppEFCore/Components/Pages/ViewContact.razor
@@ -1,5 +1,5 @@
 ﻿@page "/View/{ContactId:int}"
-@attribute [RenderModeServer]
+@rendermode RenderMode.InteractiveServer
 @using BlazorWebAppEFCore.Grid
 @using BlazorWebAppEFCore.Data
 @using Microsoft.EntityFrameworkCore

--- a/8.0/BlazorWebAppEFCore/Components/_Imports.razor
+++ b/8.0/BlazorWebAppEFCore/Components/_Imports.razor
@@ -10,3 +10,4 @@
 @using Microsoft.EntityFrameworkCore
 @using BlazorWebAppEFCore.Data
 @using BlazorWebAppEFCore.Grid
+@using static Microsoft.AspNetCore.Components.Web.RenderMode

--- a/8.0/BlazorWebAppEFCore/Program.cs
+++ b/8.0/BlazorWebAppEFCore/Program.cs
@@ -47,6 +47,7 @@ if (!app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 
 app.UseStaticFiles();
+app.UseAntiforgery();
 
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();

--- a/8.0/BlazorWebAppEFCore/Program.cs
+++ b/8.0/BlazorWebAppEFCore/Program.cs
@@ -6,7 +6,7 @@ using BlazorWebAppEFCore.Grid;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorComponents()
-    .AddServerComponents();
+    .AddInteractiveServerComponents();
 
 // Register factory and configure the options
 #region snippet1
@@ -49,6 +49,6 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 
 app.MapRazorComponents<App>()
-    .AddServerRenderMode();
+    .AddInteractiveServerRenderMode();
 
 app.Run();


### PR DESCRIPTION
In the .NET 8 version of BlazorWebAppEFCore;
- Enabled support for interactive render modes by using `AddInteractiveServerComponents` and `AddInteractiveServerRenderMode` in Program.cs as the documentation refers: https://learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?view=aspnetcore-8.0#enable-support-for-interactive-render-modes
- Used `@rendermode RenderMode.InteractiveServer` directive instead of the legacy `@attribute [RenderModeServer]` as the documentation refers: https://learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?view=aspnetcore-8.0#apply-a-render-mode-to-a-component-definition
- Added [`app.UseAntiforgery()`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.builder.antiforgeryapplicationbuilderextensions.useantiforgery?view=aspnetcore-8.0) directive in Program.cs

FYI @guardrex 