### PR TITLE
Update Identity+WASM sample

### DIFF
--- a/8.0/BlazorWebAssemblyStandaloneWithIdentity/Backend/Program.cs
+++ b/8.0/BlazorWebAssemblyStandaloneWithIdentity/Backend/Program.cs
@@ -42,11 +42,17 @@ var app = builder.Build();
 app.MapIdentityApi<AppUser>();
 
 // provide an end point to clear the cookie for logout
-app.MapPost("/Logout", async (ClaimsPrincipal user, SignInManager<AppUser> signInManager) =>
+app.MapPost("/logout", async (
+    SignInManager<MyUser> signInManager,
+    [FromBody]object empty) =>
 {
-    await signInManager.SignOutAsync();
-    return TypedResults.Ok();
-});
+    if (empty is not null)
+    {
+        await signInManager.SignOutAsync();
+        return Results.Ok();
+    }
+    return Results.NotFound();
+}).RequireAuthorization();
 
 // activate the CORS policy
 app.UseCors("wasm");


### PR DESCRIPTION
Per https://github.com/dotnet/AspNetCore.Docs/issues/31205#issuecomment-1841385405 ...

> This prevents the endpoint from accepting any forms posts. I spoke with our security team, and they indicated JSON-only endpoints that don't accept form auth or form posts don't need XSRF protections (which is why the `MapIdentityEndpoints` don't use anti-XSRF). The only way the /logout endpoint above works is if you post a JSON payload of `{}` which becomes an empty object with no properties but is not null. AFAIK this can't be done from a form.