### PR TITLE
Add roles to WASM+Identity sample app

### DIFF
--- a/8.0/BlazorWebAssemblyStandaloneWithIdentity/Backend/Program.cs
+++ b/8.0/BlazorWebAssemblyStandaloneWithIdentity/Backend/Program.cs
@@ -41,14 +41,11 @@ builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
 
-#if DEBUG
-using (var scope = app.Services.CreateScope())
+if (builder.Environment.IsDevelopment())
 {
-    var services = scope.ServiceProvider;
-
-    SeedData.Initialize(services);
+    await using var scope = app.Services.CreateAsyncScope();
+    await SeedData.InitializeAsync(scope.ServiceProvider);
 }
-#endif
 
 // create routes for the identity endpoints
 app.MapIdentityApi<AppUser>();

--- a/8.0/BlazorWebAssemblyStandaloneWithIdentity/Backend/SeedData.cs
+++ b/8.0/BlazorWebAssemblyStandaloneWithIdentity/Backend/SeedData.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace Backend;
+
+public class SeedData
+{
+    public static async void Initialize(IServiceProvider serviceProvider)
+    {
+        using var context = new AppDbContext(serviceProvider.GetRequiredService<DbContextOptions<AppDbContext>>());
+
+        if (context.Users.Any())
+        {
+            return;
+        }
+
+        string[] roles = [ "Administrator", "Manager" ];
+        using var roleManager = serviceProvider.GetRequiredService<RoleManager<IdentityRole>>();
+
+        foreach (var role in roles)
+        {
+            if (!await roleManager.RoleExistsAsync(role))
+            {
+                await roleManager.CreateAsync(new IdentityRole(role));
+
+            }
+        }
+
+        using var userManager = serviceProvider.GetRequiredService<UserManager<AppUser>>();
+
+        var user = new AppUser
+        {
+            Email = "bob@contoso.com",
+            NormalizedEmail = "BOB@CONTOSO.COM",
+            UserName = "bob@contoso.com",
+            NormalizedUserName = "BOB@CONTOSO.COM",
+            EmailConfirmed = true,
+            SecurityStamp = Guid.NewGuid().ToString("D")
+        };
+
+        var password = new PasswordHasher<AppUser>();
+        var hashed = password.HashPassword(user, "Passw0rd!");
+        user.PasswordHash = hashed;
+
+        await userManager.AddToRolesAsync(user, roles);
+
+        var userStore = new UserStore<AppUser>(context);
+        var result = userStore.CreateAsync(user);
+
+        await context.SaveChangesAsync();
+    }
+}

--- a/8.0/BlazorWebAssemblyStandaloneWithIdentity/Backend/SeedData.cs
+++ b/8.0/BlazorWebAssemblyStandaloneWithIdentity/Backend/SeedData.cs
@@ -6,7 +6,7 @@ namespace Backend;
 
 public class SeedData
 {
-    public static async void Initialize(IServiceProvider serviceProvider)
+    public static async Task InitializeAsync(IServiceProvider serviceProvider)
     {
         using var context = new AppDbContext(serviceProvider.GetRequiredService<DbContextOptions<AppDbContext>>());
 
@@ -23,7 +23,6 @@ public class SeedData
             if (!await roleManager.RoleExistsAsync(role))
             {
                 await roleManager.CreateAsync(new IdentityRole(role));
-
             }
         }
 

--- a/8.0/BlazorWebAssemblyStandaloneWithIdentity/BlazorWasmAuth/Components/Layout/NavMenu.razor
+++ b/8.0/BlazorWebAssemblyStandaloneWithIdentity/BlazorWasmAuth/Components/Layout/NavMenu.razor
@@ -31,6 +31,16 @@
                         <span class="bi bi-key" aria-hidden="true"></span> Private Page
                     </NavLink>
                 </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="private-manager-page">
+                        <span class="bi bi-key" aria-hidden="true"></span> Private Manager Page
+                    </NavLink>
+                </div>
+                <div class="nav-item px-3">
+                    <NavLink class="nav-link" href="private-editor-page">
+                        <span class="bi bi-key" aria-hidden="true"></span> Private Editor Page
+                    </NavLink>
+                </div>
             </Authorized>
         </AuthorizeView>
     </nav>

--- a/8.0/BlazorWebAssemblyStandaloneWithIdentity/BlazorWasmAuth/Components/Pages/PrivateEditorPage.razor
+++ b/8.0/BlazorWebAssemblyStandaloneWithIdentity/BlazorWasmAuth/Components/Pages/PrivateEditorPage.razor
@@ -1,0 +1,41 @@
+﻿@page "/private-editor-page"
+@attribute [Authorize(Roles = "Editor")]
+@using System.Security.Claims
+
+<PageTitle>Private Editor Page</PageTitle>
+
+<h1>Private Editor Page</h1>
+
+<AuthorizeView>
+    <p>Hello, @context.User.Identity?.Name! You're authenticated and you have an <b>Editor</b> role claim, so you can see this page.</p>
+</AuthorizeView>
+
+<h2>Claims</h2>
+
+@if (claims.Count() > 0)
+{
+    <ul>
+        @foreach (var claim in claims)
+        {
+            <li><b>@claim.Type:</b> @claim.Value</li>
+        }
+    </ul>
+}
+
+@code {
+    private IEnumerable<Claim> claims = Enumerable.Empty<Claim>();
+
+    [CascadingParameter]
+    private Task<AuthenticationState>? AuthState { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (AuthState == null)
+        {
+            return;
+        }
+
+        var authState = await AuthState;
+        claims = authState.User.Claims;
+    }
+}

--- a/8.0/BlazorWebAssemblyStandaloneWithIdentity/BlazorWasmAuth/Components/Pages/PrivateManagerPage.razor
+++ b/8.0/BlazorWebAssemblyStandaloneWithIdentity/BlazorWasmAuth/Components/Pages/PrivateManagerPage.razor
@@ -1,0 +1,41 @@
+﻿@page "/private-manager-page"
+@attribute [Authorize(Roles = "Manager")]
+@using System.Security.Claims
+
+<PageTitle>Private Manager Page</PageTitle>
+
+<h1>Private Manager Page</h1>
+
+<AuthorizeView>
+    <p>Hello, @context.User.Identity?.Name! You're authenticated and you have a <b>Manager</b> role claim, so you can see this page.</p>
+</AuthorizeView>
+
+<h2>Claims</h2>
+
+@if (claims.Count() > 0)
+{
+    <ul>
+        @foreach (var claim in claims)
+        {
+            <li><b>@claim.Type:</b> @claim.Value</li>
+        }
+    </ul>
+}
+
+@code {
+    private IEnumerable<Claim> claims = Enumerable.Empty<Claim>();
+
+    [CascadingParameter]
+    private Task<AuthenticationState>? AuthState { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (AuthState == null)
+        {
+            return;
+        }
+
+        var authState = await AuthState;
+        claims = authState.User.Claims;
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/dotnet/AspNetCore.Docs/issues/31045

Probably a fancier and more performant way to do this 🙈, but here's something to get us rolling at least for discussion.

Everything I show below is on the PR and ✨ ***Just Works!***&trade; ✨.

### Backend app

First of all, I think it's a good idea to have seeded data for learning and testing with role claims, ***AND*** I loathe having to re-register a test user over and over ... ***and over*** 😠. I place a `SeedData` class in here to take care of both. It creates a user, Bob 🤠, with two role claims (`Administrator`, `Manager`). We'll get seeded right after the app is built ...

```csharp
#if DEBUG
using (var scope = app.Services.CreateScope())
{
    var services = scope.ServiceProvider;

    SeedData.Initialize(services);
}
#endif
```

`IdentityUser` has nothing to hold roles, so I kept `AppUser`. We were going to shed it and use `IdentityUser`, but it's just as well that I didn't because we need it for roles. I added `IEnumerable<IdentityRole>` to `AppUser` ...

```csharp
class AppUser : IdentityUser
{
    public IEnumerable<IdentityRole>? Roles { get; set; }
}
```

Add roles to the Identity bits ...

```csharp
builder.Services.AddIdentityCore<AppUser>()
    .AddRoles<IdentityRole>()
    .AddEntityFrameworkStores<AppDbContext>()
    .AddApiEndpoints();
```

We need some kind of endpoint for the frontend to tap for the user's roles, so I went with the following Minimal API approach ...

```csharp
app.MapGet("/roles", (ClaimsPrincipal user) =>
{
    if (user.Identity is not null && user.Identity.IsAuthenticated)
    {
        var identity = (ClaimsIdentity)user.Identity;
        var roles = identity.FindAll(identity.RoleClaimType)
            .Select(c => 
                new
                {
                    c.Issuer, 
                    c.OriginalIssuer, 
                    c.Type, 
                    c.Value, 
                    c.ValueType
                });

        return TypedResults.Json(roles);
    }

    return Results.Unauthorized();
});
```

*Ugh!* ... that's :point_up: probably more rotten 🙈 ***RexHaqs!***&trade; code 🙈. I couldn't get a `Claim[]` array to play nicely with `TypedResults.Json` because `Claim` doesn't have a parameterless ctor and the JSON serializer usually flakes out in a ☠️  loop, perhaps because the claim's `Subject` has a claims collection. I'm not familiar with source generators/reflection concepts in `System.Text.Json` serialization, but I did have a little luck with ...

```csharp
var roles = identity.FindAll(identity.RoleClaimType).ToArray();

var serializerOptions = new JsonSerializerOptions()
{
    ReferenceHandler = ReferenceHandler.Preserve,
    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
};

return TypedResults.Json(roles, serializerOptions);
```

However, that only (apparently) sends down the `Administrator` role claim. It doesn't send the other role claim for `Manager`. The simplest way for me to solve this was to select (`.Select`) what's needed from the claims into an `IEnumerable` and run the JSON serializer on that to send the role claims.

The PU is welcome to fix this with a proper source generator and make it work with a normal `Claim[]` array (`ToArray`). The silly 🦖 will watch and learn!

### BlazorWasmAuth app

Added two pages: One requires a `Manager` role claim, and the other requires an `Editor` role claim. I added links to them to the `NavMenu`, and the links show up when merely authenticated. That's by-design because we want to demo that the `Editor` page can't be reached by Bob 🤠 the test user with only `Administrator` and `Manager` role claims.

The action takes place in the `CookieAuthenticationStateProvider`'s `GetAuthenticationStateAsync` method. I add the following to make claims out of the role claims that come down from tapping the `/roles` endpoint of the Backend app.

First, something to receive the claims. Again, trying to use a `Claim[]` array flakes out the JSON serializer without source gen. Using a custom class is the low-hanging-🍎  approach. ... ***and again,*** the PU is welcome to fix this to just deserialize with a `Claim[]` array.

```csharp
public class RoleClaim
{
    public string? Issuer { get; set; }
    public string? OriginalIssuer { get; set; }
    public string? Type { get; set; }
    public string? Value { get; set; }
    public string? ValueType { get; set; }
}
```

... and just before the `ClaimsIdentity` is created in `GetAuthenticationStateAsync`  ...

```csharp
// tap the roles endpoint for the user's roles
var rolesResponse = await _httpClient.GetAsync("roles");

// throw if request fails
rolesResponse.EnsureSuccessStatusCode();

// read the response into a string
var rolesJson = await rolesResponse.Content.ReadAsStringAsync();

// deserialize the roles string into an array
var roles = JsonSerializer.Deserialize<RoleClaim[]>(rolesJson, jsonSerializerOptions);

// if there are roles, add them to the claims collection
if (roles?.Length > 0)
{
    foreach (var role in roles)
    {
        if (!string.IsNullOrEmpty(role.Type) && !string.IsNullOrEmpty(role.Value))
        {
            claims.Add(new Claim(role.Type, role.Value, role.ValueType, role.Issuer, role.OriginalIssuer));
        }
    }
}
```

The role claims JSON (formatted for display here) returned by the `/roles` endpoint when run locally for the example:

```json
[
    {
    "issuer" : "LOCAL AUTHORITY",
    "originalIssuer" : "LOCAL AUTHORITY",
    "name" : "bob@contoso.com",
    "type" : "http://schemas.microsoft.com/ws/2008/06/identity/claims/role",
    "value" : "Administrator",
    "valueType" : "http://www.w3.org/2001/XMLSchema#string"
    },
    {
    "issuer" : "LOCAL AUTHORITY",
    "originalIssuer" : "LOCAL AUTHORITY",
    "name" : "bob@contoso.com",
    "type" : "http://schemas.microsoft.com/ws/2008/06/identity/claims/role",
    "value" : "Manager",
    "valueType" : "http://www.w3.org/2001/XMLSchema#string"
    }
]
```