### PR TITLE
Add Render Mode to PrerenderedCounter2.razor

### DIFF
--- a/8.0/BlazorSample_BlazorWebApp/Components/Pages/PrerenderedCounter2.razor
+++ b/8.0/BlazorSample_BlazorWebApp/Components/Pages/PrerenderedCounter2.razor
@@ -1,5 +1,6 @@
 ﻿@page "/prerendered-counter-2"
 @implements IDisposable
+@rendermode @(new InteractiveServerRenderMode(prerender: true))
 @inject ILogger<PrerenderedCounter2> Logger
 @inject PersistentComponentState ApplicationState
 


### PR DESCRIPTION
The @rendermode directive seems to be missing so the page is not interactive (if you click the increment counter button nothing change).