### PR TITLE
DetectIncorrectUsagesOfTransientDisposables - implementation alignment

### DIFF
--- a/3.1/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/3.1/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -123,7 +123,7 @@ namespace BlazorServerTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                ServiceLifetime.Transient);
+                original.Lifetime);
     
             return newDescriptor;
         }

--- a/3.1/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/3.1/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -97,7 +97,7 @@ namespace BlazorServerTransientDisposable
 
                     return originalResult;
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
 
             return newDescriptor;
         }
@@ -123,7 +123,7 @@ namespace BlazorServerTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
     
             return newDescriptor;
         }

--- a/3.1/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/3.1/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -92,7 +92,7 @@ namespace BlazorWebAssemblyTransientDisposable
 
                     return originalResult;
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
 
             return newDescriptor;
         }
@@ -116,7 +116,7 @@ namespace BlazorWebAssemblyTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
     
             return newDescriptor;
         }

--- a/3.1/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/3.1/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -116,7 +116,7 @@ namespace BlazorWebAssemblyTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                ServiceLifetime.Transient);
+                original.Lifetime);
     
             return newDescriptor;
         }

--- a/5.0/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/5.0/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -123,7 +123,7 @@ namespace BlazorServerTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                ServiceLifetime.Transient);
+                original.Lifetime);
     
             return newDescriptor;
         }

--- a/5.0/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/5.0/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -97,7 +97,7 @@ namespace BlazorServerTransientDisposable
 
                     return originalResult;
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
 
             return newDescriptor;
         }
@@ -123,7 +123,7 @@ namespace BlazorServerTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
     
             return newDescriptor;
         }

--- a/5.0/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/5.0/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -92,7 +92,7 @@ namespace BlazorWebAssemblyTransientDisposable
 
                     return originalResult;
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
 
             return newDescriptor;
         }
@@ -116,7 +116,7 @@ namespace BlazorWebAssemblyTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
     
             return newDescriptor;
         }

--- a/5.0/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/5.0/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -116,7 +116,7 @@ namespace BlazorWebAssemblyTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                ServiceLifetime.Transient);
+                original.Lifetime);
     
             return newDescriptor;
         }

--- a/6.0/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/6.0/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -132,7 +132,7 @@ namespace BlazorServerTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                ServiceLifetime.Transient);
+                original.Lifetime);
     
             return newDescriptor;
         }

--- a/6.0/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/6.0/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -100,7 +100,7 @@ namespace BlazorServerTransientDisposable
 
                     return originalResult;
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
 
             return newDescriptor;
         }
@@ -132,7 +132,7 @@ namespace BlazorServerTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
     
             return newDescriptor;
         }

--- a/6.0/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/6.0/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -97,7 +97,7 @@ namespace BlazorWebAssemblyTransientDisposable
 
                     return originalResult;
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
 
             return newDescriptor;
         }
@@ -127,7 +127,7 @@ namespace BlazorWebAssemblyTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
     
             return newDescriptor;
         }

--- a/6.0/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/6.0/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -127,7 +127,7 @@ namespace BlazorWebAssemblyTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                ServiceLifetime.Transient);
+                original.Lifetime);
     
             return newDescriptor;
         }

--- a/7.0/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/7.0/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -132,7 +132,7 @@ namespace BlazorServerTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                ServiceLifetime.Transient);
+                original.Lifetime);
     
             return newDescriptor;
         }

--- a/7.0/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/7.0/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -100,7 +100,7 @@ namespace BlazorServerTransientDisposable
 
                     return originalResult;
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
 
             return newDescriptor;
         }
@@ -132,7 +132,7 @@ namespace BlazorServerTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
     
             return newDescriptor;
         }

--- a/7.0/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/7.0/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -97,7 +97,7 @@ namespace BlazorWebAssemblyTransientDisposable
 
                     return originalResult;
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
 
             return newDescriptor;
         }
@@ -127,7 +127,7 @@ namespace BlazorWebAssemblyTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
     
             return newDescriptor;
         }

--- a/7.0/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/7.0/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -127,7 +127,7 @@ namespace BlazorWebAssemblyTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                ServiceLifetime.Transient);
+                original.Lifetime);
     
             return newDescriptor;
         }

--- a/8.0/BlazorSample_BlazorWebApp/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/8.0/BlazorSample_BlazorWebApp/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -127,7 +127,7 @@ namespace BlazorServerTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-				original.Lifetime);
+                original.Lifetime);
     
             return newDescriptor;
         }

--- a/8.0/BlazorSample_BlazorWebApp/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/8.0/BlazorSample_BlazorWebApp/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -95,7 +95,7 @@ namespace BlazorServerTransientDisposable
 
                     return originalResult;
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
 
             return newDescriptor;
         }
@@ -127,7 +127,7 @@ namespace BlazorServerTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                original.Lifetime);
+				ServiceLifetime.Transient);
     
             return newDescriptor;
         }

--- a/8.0/BlazorSample_BlazorWebApp/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/8.0/BlazorSample_BlazorWebApp/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -127,7 +127,7 @@ namespace BlazorServerTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-                ServiceLifetime.Transient);
+				original.Lifetime);
     
             return newDescriptor;
         }

--- a/8.0/BlazorSample_BlazorWebApp/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/8.0/BlazorSample_BlazorWebApp/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -127,7 +127,7 @@ namespace BlazorServerTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp, 
                         original.ImplementationType);
                 },
-				ServiceLifetime.Transient);
+                ServiceLifetime.Transient);
     
             return newDescriptor;
         }

--- a/8.0/BlazorSample_WebAssembly/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/8.0/BlazorSample_WebAssembly/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -123,7 +123,7 @@ namespace BlazorWebAssemblyTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp,
                         original.ImplementationType);
                 },
-                ServiceLifetime.Transient);
+				original.Lifetime);
 
             return newDescriptor;
         }

--- a/8.0/BlazorSample_WebAssembly/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/8.0/BlazorSample_WebAssembly/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -123,7 +123,7 @@ namespace BlazorWebAssemblyTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp,
                         original.ImplementationType);
                 },
-				original.Lifetime);
+                original.Lifetime);
 
             return newDescriptor;
         }

--- a/8.0/BlazorSample_WebAssembly/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/8.0/BlazorSample_WebAssembly/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -123,7 +123,7 @@ namespace BlazorWebAssemblyTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp,
                         original.ImplementationType);
                 },
-				ServiceLifetime.Transient);
+                ServiceLifetime.Transient);
 
             return newDescriptor;
         }

--- a/8.0/BlazorSample_WebAssembly/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/8.0/BlazorSample_WebAssembly/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -92,7 +92,7 @@ namespace BlazorWebAssemblyTransientDisposable
 
                     return originalResult;
                 },
-                original.Lifetime);
+                ServiceLifetime.Transient);
 
             return newDescriptor;
         }
@@ -123,7 +123,7 @@ namespace BlazorWebAssemblyTransientDisposable
                     return ActivatorUtilities.CreateInstance(sp,
                         original.ImplementationType);
                 },
-                original.Lifetime);
+				ServiceLifetime.Transient);
 
             return newDescriptor;
         }


### PR DESCRIPTION
The `CreatePatchedDescriptor()` and `CreatePatchedFactoryDescriptor()` methods both create a new descriptor based on the original descriptor. However, it's unclear why `CreatePatchedDescriptor` method hardcodes `ServiceLifetime.Transient`, whereas `CreatePatchedFactoryDescriptor` uses `original.Lifetime` for the same intended outcome.

I believe the example implementation should avoid raising such questions among readers, and thus I recommend using a consistent approach in both methods.