### PR TITLE
Move transient disposables code

### DIFF
--- a/3.1/BlazorSample_Server/Services/TransitiveTransientDisposableDependency.cs
+++ b/3.1/BlazorSample_Server/Services/TransitiveTransientDisposableDependency.cs
@@ -1,4 +1,4 @@
-namespace BlazorSample;
+namespace BlazorSample.Services;
 
 public class TransitiveTransientDisposableDependency
     : ITransitiveTransientDisposableDependency, IDisposable

--- a/3.1/BlazorSample_Server/Startup.cs
+++ b/3.1/BlazorSample_Server/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using BlazorSample.Data;
+using BlazorSample.Services;
 
 namespace BlazorSample
 {

--- a/5.0/BlazorSample_Server/Services/TransitiveTransientDisposableDependency.cs
+++ b/5.0/BlazorSample_Server/Services/TransitiveTransientDisposableDependency.cs
@@ -1,4 +1,4 @@
-namespace BlazorSample;
+namespace BlazorSample.Services;
 
 public class TransitiveTransientDisposableDependency
     : ITransitiveTransientDisposableDependency, IDisposable

--- a/5.0/BlazorSample_Server/Startup.cs
+++ b/5.0/BlazorSample_Server/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using BlazorSample.Data;
+using BlazorSample.Services;
 
 namespace BlazorSample
 {

--- a/6.0/BlazorSample_Server/Program.cs
+++ b/6.0/BlazorSample_Server/Program.cs
@@ -1,3 +1,5 @@
+using BlazorSample.Services;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.

--- a/6.0/BlazorSample_Server/Services/TransitiveTransientDisposableDependency.cs
+++ b/6.0/BlazorSample_Server/Services/TransitiveTransientDisposableDependency.cs
@@ -1,4 +1,4 @@
-namespace BlazorSample;
+namespace BlazorSample.Services;
 
 public class TransitiveTransientDisposableDependency
     : ITransitiveTransientDisposableDependency, IDisposable

--- a/7.0/BlazorSample_Server/Program.cs
+++ b/7.0/BlazorSample_Server/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using BlazorSample.Data;
+using BlazorSample.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/7.0/BlazorSample_Server/Services/TransitiveTransientDisposableDependency.cs
+++ b/7.0/BlazorSample_Server/Services/TransitiveTransientDisposableDependency.cs
@@ -1,4 +1,4 @@
-namespace BlazorSample;
+namespace BlazorSample.Services;
 
 public class TransitiveTransientDisposableDependency
     : ITransitiveTransientDisposableDependency, IDisposable


### PR DESCRIPTION
Moving the transient disposables code in <8.0 samps to a `Services` folder with a new namespace. This is to match the 8.0 sample and make the article text clean on the location of the file.