### PR TITLE
Add .editorconfig to help maintain coding standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = crlf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+
+[*.{cs,cshtml,html,razor}]
+indent_size = 4
+
+[*.cs]
+dotnet_sort_system_directives_first = true
+
+[*.md]
+max_line_length = off

--- a/8.0/BlazorSample_BlazorWebApp/Components/Layout/MainLayout.razor
+++ b/8.0/BlazorSample_BlazorWebApp/Components/Layout/MainLayout.razor
@@ -1,29 +1,39 @@
 ﻿@inherits LayoutComponentBase
 
 <div class="page">
-    <div class="sidebar">
-        <NavMenu />
-    </div>
+	<div class="sidebar">
+		<NavMenu />
+	</div>
 
-    <main>
-        <div class="top-row px-4">
-            <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
-        </div>
+	<main>
+		<div class="top-row px-4">
+			<a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
+		</div>
 
-        <CascadingValue Value="@theme">
-            <article class="content px-4">
-                @Body
-            </article>
-        </CascadingValue>
-    </main>
+		<CascadingValue Value="@theme">
+			<article class="content px-4">
+				<ErrorBoundary>
+					<ChildContent>
+						@Body
+					</ChildContent>
+					<ErrorContent>
+						<p class="alert alert-danger" role="alert">
+							Oh, dear! Oh, my! - George Takei
+							@context
+						</p>
+					</ErrorContent>
+				</ErrorBoundary>
+			</article>
+		</CascadingValue>
+	</main>
 </div>
 
 <div id="blazor-error-ui" data-nosnippet>
-    An unhandled error has occurred.
-    <a href="" class="reload">Reload</a>
-    <a class="dismiss">🗙</a>
+	An unhandled error has occurred.
+	<a href="" class="reload">Reload</a>
+	<a class="dismiss">🗙</a>
 </div>
 
 @code {
-    private ThemeInfo theme = new() { ButtonClass = "btn-success" };
+	private ThemeInfo theme = new() { ButtonClass = "btn-success" };
 }

--- a/8.0/BlazorSample_BlazorWebApp/Components/Pages/Notifications.razor
+++ b/8.0/BlazorSample_BlazorWebApp/Components/Pages/Notifications.razor
@@ -14,38 +14,44 @@
 <h2>Notifications</h2>
 
 <p>
-    Status:
-    @if (lastNotification.key is not null)
-    {
-        <span>@lastNotification.key = @lastNotification.value</span>
-    }
-    else
-    {
-        <span>Awaiting first notification</span>
-    }
+	Status:
+	@if (lastNotification.key is not null)
+	{
+		<span>@lastNotification.key = @lastNotification.value</span>
+	}
+	else
+	{
+		<span>Awaiting first notification</span>
+	}
 </p>
 
 @code {
-    private (string key, int value) lastNotification;
+	private (string key, int value) lastNotification;
 
-    protected override void OnInitialized()
-    {
-        Notifier.Notify += OnNotify;
-    }
+	protected override void OnInitialized()
+	{
+		Notifier.Notify += OnNotify;
+		Notifier.NotifyException += OnNotifyException;
+	}
 
-    public async Task OnNotify(string key, int value)
-    {
-        await InvokeAsync(() =>
-        {
-            lastNotification = (key, value);
-            StateHasChanged();
-        });
-    }
+	public async Task OnNotify(string key, int value)
+	{
+		await InvokeAsync(() =>
+		{
+			lastNotification = (key, value);
+			StateHasChanged();
+		});
+	}
 
-    private async Task StartTimer()
-    {
-        await Timer.Start();
-    }
+	private async Task OnNotifyException(Exception ex)
+	{
+		await DispatchExceptionAsync(ex);
+	}
 
-    public void Dispose() => Notifier.Notify -= OnNotify;
+	private void StartTimer()
+	{
+		_ = Timer.Start();
+	}
+
+	public void Dispose() => Notifier.Notify -= OnNotify;
 }

--- a/8.0/BlazorSample_BlazorWebApp/NotifierService.cs
+++ b/8.0/BlazorSample_BlazorWebApp/NotifierService.cs
@@ -10,5 +10,14 @@ public class NotifierService
         }
     }
 
-    public event Func<string, int, Task>? Notify;
+	public async Task DispatchException(Exception ex)
+	{
+		if (NotifyException != null)
+		{
+			await NotifyException.Invoke(ex);
+		}
+	}
+
+	public event Func<string, int, Task>? Notify;
+	public event Func<Exception, Task>? NotifyException;
 }

--- a/8.0/BlazorSample_BlazorWebApp/TimerService.cs
+++ b/8.0/BlazorSample_BlazorWebApp/TimerService.cs
@@ -20,9 +20,20 @@ public class TimerService(NotifierService notifier,
             {
                 while (await timer.WaitForNextTickAsync())
                 {
-                    elapsedCount += 1;
-                    await notifier.Update("elapsedCount", elapsedCount);
-                    logger.LogInformation("ElapsedCount {Count}", elapsedCount);
+					try
+					{
+						elapsedCount += 1;
+						if (elapsedCount == 2)
+						{
+							throw new Exception("I threw an exception! Somebody help me!");
+						}
+						await notifier.Update("elapsedCount", elapsedCount);
+						logger.LogInformation("ElapsedCount {Count}", elapsedCount);
+					}
+					catch (Exception ex)
+					{
+						await notifier.DispatchException(ex);
+					}
                 }
             }
         }


### PR DESCRIPTION
@guardrex 
>BTW ... This doesn't matter here, but I think I've noticed from a couple of your PRs that you're using tabs there in your code base. Note that we use spaces per the PU coding guidelines. I just mention it for future PR submissions.

I've taken the minimalistic `.editorconfig` from the AspNetCore.Docs repo.
The most important directive is to prefer spaces over tabs for indentation. ;-)