### PR TITLE
Reset details to null

### DIFF
--- a/3.1/BlazorSample_Server/Pages/handle-errors/ProductDetails.razor
+++ b/3.1/BlazorSample_Server/Pages/handle-errors/ProductDetails.razor
@@ -29,6 +29,10 @@ else
         try
         {
             loadFailed = false;
+
+            // Reset details to null to display the loading indicator
+            details = null;
+
             details = await ProductRepository.GetProductByIdAsync(ProductId);
         }
         catch (Exception ex)

--- a/3.1/BlazorSample_WebAssembly/Pages/handle-errors/ProductDetails.razor
+++ b/3.1/BlazorSample_WebAssembly/Pages/handle-errors/ProductDetails.razor
@@ -29,6 +29,10 @@ else
         try
         {
             loadFailed = false;
+
+            // Reset details to null to display the loading indicator
+            details = null;
+
             details = await ProductRepository.GetProductByIdAsync(ProductId);
         }
         catch (Exception ex)

--- a/5.0/BlazorSample_Server/Pages/handle-errors/ProductDetails.razor
+++ b/5.0/BlazorSample_Server/Pages/handle-errors/ProductDetails.razor
@@ -29,6 +29,10 @@ else
         try
         {
             loadFailed = false;
+
+            // Reset details to null to display the loading indicator
+            details = null;
+
             details = await ProductRepository.GetProductByIdAsync(ProductId);
         }
         catch (Exception ex)

--- a/5.0/BlazorSample_WebAssembly/Pages/handle-errors/ProductDetails.razor
+++ b/5.0/BlazorSample_WebAssembly/Pages/handle-errors/ProductDetails.razor
@@ -29,6 +29,10 @@ else
         try
         {
             loadFailed = false;
+
+            // Reset details to null to display the loading indicator
+            details = null;
+
             details = await ProductRepository.GetProductByIdAsync(ProductId);
         }
         catch (Exception ex)

--- a/6.0/BlazorSample_Server/Pages/handle-errors/ProductDetails.razor
+++ b/6.0/BlazorSample_Server/Pages/handle-errors/ProductDetails.razor
@@ -29,6 +29,10 @@ else
         try
         {
             loadFailed = false;
+
+            // Reset details to null to display the loading indicator
+            details = null;
+
             details = await ProductRepository.GetProductByIdAsync(ProductId);
         }
         catch (Exception ex)

--- a/6.0/BlazorSample_WebAssembly/Pages/handle-errors/ProductDetails.razor
+++ b/6.0/BlazorSample_WebAssembly/Pages/handle-errors/ProductDetails.razor
@@ -29,6 +29,10 @@ else
         try
         {
             loadFailed = false;
+
+            // Reset details to null to display the loading indicator
+            details = null;
+
             details = await ProductRepository.GetProductByIdAsync(ProductId);
         }
         catch (Exception ex)

--- a/7.0/BlazorSample_Server/Pages/handle-errors/ProductDetails.razor
+++ b/7.0/BlazorSample_Server/Pages/handle-errors/ProductDetails.razor
@@ -29,6 +29,10 @@ else
         try
         {
             loadFailed = false;
+
+            // Reset details to null to display the loading indicator
+            details = null;
+
             details = await ProductRepository.GetProductByIdAsync(ProductId);
         }
         catch (Exception ex)

--- a/7.0/BlazorSample_WebAssembly/Pages/handle-errors/ProductDetails.razor
+++ b/7.0/BlazorSample_WebAssembly/Pages/handle-errors/ProductDetails.razor
@@ -29,6 +29,10 @@ else
         try
         {
             loadFailed = false;
+
+            // Reset details to null to display the loading indicator
+            details = null;
+
             details = await ProductRepository.GetProductByIdAsync(ProductId);
         }
         catch (Exception ex)

--- a/8.0/BlazorSample_BlazorWebApp/Components/Pages/ProductDetails.razor
+++ b/8.0/BlazorSample_BlazorWebApp/Components/Pages/ProductDetails.razor
@@ -36,6 +36,10 @@ else
         try
         {
             loadFailed = false;
+
+            // Reset details to null to display the loading indicator
+            details = null;
+
             details = await Product.GetProductByIdAsync(ProductId);
         }
         catch (Exception ex)

--- a/8.0/BlazorSample_WebAssembly/Pages/ProductDetails.razor
+++ b/8.0/BlazorSample_WebAssembly/Pages/ProductDetails.razor
@@ -35,6 +35,10 @@ else
         try
         {
             loadFailed = false;
+
+            // Reset details to null to display the loading indicator
+            details = null;
+
             details = await Product.GetProductByIdAsync(ProductId);
         }
         catch (Exception ex)


### PR DESCRIPTION
Fixes #188

Look good, @hakenr? ... I'd like to leave the code comment in place on this one. I usually prefer to manage this in the article text because code comments aren't localized. However, this is a minor point that I'd prefer not to call out in the text in this case. I added a bit of padding around it as well. It presents well in the article this way.