### PR TITLE
Random.Shared instead of new Random() (net6+)

### DIFF
--- a/6.0/BlazorSample_Server/lifecycle/WeatherForecastService.cs
+++ b/6.0/BlazorSample_Server/lifecycle/WeatherForecastService.cs
@@ -25,15 +25,13 @@ public class WeatherForecastService
                     TimeSpan.FromSeconds(30)
             });
 
-            var rng = new Random();
-
             await Task.Delay(TimeSpan.FromSeconds(10));
 
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = startDate.AddDays(index),
-                TemperatureC = rng.Next(-20, 55),
-                Summary = summaries[rng.Next(summaries.Length)]
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = summaries[Random.Shared.Next(summaries.Length)]
             }).ToArray();
         });
     }

--- a/7.0/BlazorSample_Server/lifecycle/WeatherForecastService.cs
+++ b/7.0/BlazorSample_Server/lifecycle/WeatherForecastService.cs
@@ -25,15 +25,13 @@ public class WeatherForecastService
                     TimeSpan.FromSeconds(30)
             });
 
-            var rng = new Random();
-
             await Task.Delay(TimeSpan.FromSeconds(10));
 
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = startDate.AddDays(index),
-                TemperatureC = rng.Next(-20, 55),
-                Summary = summaries[rng.Next(summaries.Length)]
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = summaries[Random.Shared.Next(summaries.Length)]
             }).ToArray();
         });
     }

--- a/8.0/BlazorSample_BlazorWebApp/Components/Pages/PrerenderedCounter1.razor
+++ b/8.0/BlazorSample_BlazorWebApp/Components/Pages/PrerenderedCounter1.razor
@@ -1,4 +1,4 @@
-﻿@page "/prerendered-counter-1"
+@page "/prerendered-counter-1"
 @rendermode @(new InteractiveServerRenderMode(prerender: true))
 @inject ILogger<PrerenderedCounter1> Logger
 
@@ -12,11 +12,10 @@
 
 @code {
     private int currentCount;
-    private Random r = new Random();
 
     protected override void OnInitialized()
     {
-        currentCount = r.Next(100);
+        currentCount = Random.Shared.Next(100);
         Logger.LogInformation("currentCount set to {Count}", currentCount);
     }
 

--- a/8.0/BlazorSample_BlazorWebApp/Components/Pages/PrerenderedCounter2.razor
+++ b/8.0/BlazorSample_BlazorWebApp/Components/Pages/PrerenderedCounter2.razor
@@ -1,4 +1,4 @@
-﻿@page "/prerendered-counter-2"
+@page "/prerendered-counter-2"
 @implements IDisposable
 @inject ILogger<PrerenderedCounter2> Logger
 @inject PersistentComponentState ApplicationState
@@ -13,7 +13,6 @@
 
 @code {
     private int currentCount;
-    private Random r = new Random();
     private PersistingComponentStateSubscription persistingSubscription;
 
     protected override void OnInitialized()
@@ -24,7 +23,7 @@
         if (!ApplicationState.TryTakeFromJson<int>(
             "count", out var restoredCount))
         {
-            currentCount = r.Next(100);
+            currentCount = Random.Shared.Next(100);
             Logger.LogInformation("currentCount set to {Count}", currentCount);
         }
         else

--- a/8.0/BlazorSample_BlazorWebApp/WeatherForecastService.cs
+++ b/8.0/BlazorSample_BlazorWebApp/WeatherForecastService.cs
@@ -22,15 +22,13 @@ public class WeatherForecastService(IMemoryCache memoryCache)
                     TimeSpan.FromSeconds(30)
             });
 
-            var rng = new Random();
-
             await Task.Delay(TimeSpan.FromSeconds(10));
 
             return Enumerable.Range(1, 5).Select(index => new WeatherForecast
             {
                 Date = startDate.AddDays(index),
-                TemperatureC = rng.Next(-20, 55),
-                Summary = summaries[rng.Next(summaries.Length)]
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = summaries[Random.Shared.Next(summaries.Length)]
             }).ToArray();
         });
     }


### PR DESCRIPTION
.NET 6 introduced `Random.Shared` for scenarios where a specific seed value isn't required.

cc @guardrex 