### PR TITLE
FIx build (net7 TransientService.razor)

### DIFF
--- a/7.0/BlazorSample_Server/Pages/dependency-injection/TransientService.razor
+++ b/7.0/BlazorSample_Server/Pages/dependency-injection/TransientService.razor
@@ -1,4 +1,5 @@
 @page "/transient-service"
+@using BlazorSample.Services
 @inject TransientDependency TransientDependency
 
 <h1>Transient Disposable Detection</h1>


### PR DESCRIPTION
The `7.0\BlazorSample_Server` was still not buildable.
Adding missing `using` to `TransientService.razor`

cc @guardrex 