### PR TITLE
Synchronization context sample - fire&forget for Timer.Start

### DIFF
--- a/6.0/BlazorSample_Server/Pages/synchronization-context/ReceiveNotifications.razor
+++ b/6.0/BlazorSample_Server/Pages/synchronization-context/ReceiveNotifications.razor
@@ -40,9 +40,9 @@
         });
     }
 
-    private async Task StartTimer()
+    private void StartTimer()
     {
-        await Timer.Start();
+        _ = Task.Run(Timer.Start);
     }
 
     public void Dispose()

--- a/6.0/BlazorSample_WebAssembly/Pages/synchronization-context/ReceiveNotifications.razor
+++ b/6.0/BlazorSample_WebAssembly/Pages/synchronization-context/ReceiveNotifications.razor
@@ -40,9 +40,9 @@
         });
     }
 
-    private async Task StartTimer()
+    private void StartTimer()
     {
-        await Timer.Start();
+        _ = Task.Run(Timer.Start);
     }
 
     public void Dispose()

--- a/7.0/BlazorSample_Server/Pages/synchronization-context/ReceiveNotifications.razor
+++ b/7.0/BlazorSample_Server/Pages/synchronization-context/ReceiveNotifications.razor
@@ -40,9 +40,9 @@
         });
     }
 
-    private async Task StartTimer()
+    private void StartTimer()
     {
-        await Timer.Start();
+        _ = Task.Run(Timer.Start);
     }
 
     public void Dispose()

--- a/7.0/BlazorSample_WebAssembly/Pages/synchronization-context/ReceiveNotifications.razor
+++ b/7.0/BlazorSample_WebAssembly/Pages/synchronization-context/ReceiveNotifications.razor
@@ -40,9 +40,9 @@
         });
     }
 
-    private async Task StartTimer()
+    private void StartTimer()
     {
-        await Timer.Start();
+        _ = Task.Run(Timer.Start);
     }
 
     public void Dispose()

--- a/8.0/BlazorSample_BlazorWebApp/Components/Pages/Notifications.razor
+++ b/8.0/BlazorSample_BlazorWebApp/Components/Pages/Notifications.razor
@@ -1,4 +1,4 @@
-﻿@page "/notifications"
+@page "/notifications"
 @implements IDisposable
 @inject NotifierService Notifier
 @inject TimerService Timer
@@ -42,9 +42,9 @@
         });
     }
 
-    private async Task StartTimer()
+    private void StartTimer()
     {
-        await Timer.Start();
+        _= Task.Run(Timer.Start);
     }
 
     public void Dispose() => Notifier.Notify -= OnNotify;

--- a/8.0/BlazorSample_BlazorWebApp/Components/Pages/Notifications.razor
+++ b/8.0/BlazorSample_BlazorWebApp/Components/Pages/Notifications.razor
@@ -44,7 +44,7 @@
 
     private void StartTimer()
     {
-        _= Task.Run(Timer.Start);
+        _ = Task.Run(Timer.Start);
     }
 
     public void Dispose() => Notifier.Notify -= OnNotify;

--- a/8.0/BlazorSample_WebAssembly/Pages/Notifications.razor
+++ b/8.0/BlazorSample_WebAssembly/Pages/Notifications.razor
@@ -1,4 +1,4 @@
-﻿@page "/notifications"
+@page "/notifications"
 @implements IDisposable
 @inject NotifierService Notifier
 @inject TimerService Timer
@@ -42,9 +42,9 @@
         });
     }
 
-    private async Task StartTimer()
+    private void StartTimer()
     {
-        await Timer.Start();
+        _ = Task.Run(Timer.Start);
     }
 
     public void Dispose() => Notifier.Notify -= OnNotify;


### PR DESCRIPTION
@guardrex, similar to our discussion on `DispatchExceptionAsync()`, the latest version of `TimerService.cs` (net6+) now uses `await timer.WaitForNextTickAsync()` within the asynchronous `Timer.Start()` method. This approach ensures all notifications are processed within the Blazor synchronization context (logical thread) when the Timer.Start is awaited from the button click event handler.

This setup means that `Notifications.razor` operates correctly even without utilizing the `InvokeAsync()` method.

To effectively illustrate the necessity for `InvokeAsync()`, we should execute the `Timer` outside the Blazor synchronization context (e.g. as a background service). This can be demonstrated by initiating it with `_ = Task.Run(() => Timer.Start())`. (It still functions without `InvokeAsync` in WASM, but that's a topic for another conversation.)