### PR TITLE
Expanders - continuation (net8-wasm, net7, net6, net5, net3.1)

### DIFF
--- a/3.1/BlazorSample_Server/Pages/overwriting-parameters/Expanders.razor
+++ b/3.1/BlazorSample_Server/Pages/overwriting-parameters/Expanders.razor
@@ -1,0 +1,13 @@
+@page "/expanders"
+
+<PageTitle>Expanders</PageTitle>
+
+<h1>Expanders Example</h1>
+
+<ShowMoreExpander InitiallyExpanded="false">
+    Expander 1 content
+</ShowMoreExpander>
+
+<ShowMoreExpander InitiallyExpanded="false" />
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>

--- a/3.1/BlazorSample_Server/Pages/overwriting-parameters/ExpandersToggle.razor
+++ b/3.1/BlazorSample_Server/Pages/overwriting-parameters/ExpandersToggle.razor
@@ -1,0 +1,22 @@
+@page "/expanders-toggle"
+
+<PageTitle>Expanders Toggle</PageTitle>
+
+<h1>Expanders Toggle</h1>
+
+<ToggleExpander @bind-Expanded="expanded">
+    Expander content
+</ToggleExpander>
+
+<button @onclick="Toggle">Toggle</button>
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>
+
+@code {
+    private bool expanded;
+
+    private void Toggle()
+    {
+        expanded = !expanded;
+    }
+}

--- a/3.1/BlazorSample_Server/Shared/overwriting-parameters/BadShowMoreExpander.razor
+++ b/3.1/BlazorSample_Server/Shared/overwriting-parameters/BadShowMoreExpander.razor
@@ -1,0 +1,24 @@
+<div @onclick="ShowMore" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @InitiallyExpanded)</h2>
+    </div>
+    @if (InitiallyExpanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private void ShowMore()
+    {
+        InitiallyExpanded = true;
+    }
+}

--- a/3.1/BlazorSample_Server/Shared/overwriting-parameters/ShowMoreExpander.razor
+++ b/3.1/BlazorSample_Server/Shared/overwriting-parameters/ShowMoreExpander.razor
@@ -1,0 +1,31 @@
+<div @onclick="Expand" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    private bool expanded;
+
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    protected override void OnInitialized()
+    {
+        expanded = InitiallyExpanded;
+    }
+
+    private void Expand()
+    {
+        expanded = true;
+    }
+}

--- a/3.1/BlazorSample_Server/Shared/overwriting-parameters/ToggleExpander.razor
+++ b/3.1/BlazorSample_Server/Shared/overwriting-parameters/ToggleExpander.razor
@@ -1,0 +1,35 @@
+<div class="card bg-light mb-3" style="width:30rem">
+    <div @onclick="Toggle" class="card-header">
+        <h2 class="card-title">Toggle (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool Expanded { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> ExpandedChanged { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private bool expanded;
+
+    protected override void OnParametersSet()
+    {
+        expanded = Expanded;
+    }
+
+    private async void Toggle()
+    {
+        expanded = !expanded;
+        await ExpandedChanged.InvokeAsync(expanded);
+    }
+}

--- a/3.1/BlazorSample_WebAssembly/Pages/overwriting-parameters/Expanders.razor
+++ b/3.1/BlazorSample_WebAssembly/Pages/overwriting-parameters/Expanders.razor
@@ -1,0 +1,13 @@
+@page "/expanders"
+
+<PageTitle>Expanders</PageTitle>
+
+<h1>Expanders Example</h1>
+
+<ShowMoreExpander InitiallyExpanded="false">
+    Expander 1 content
+</ShowMoreExpander>
+
+<ShowMoreExpander InitiallyExpanded="false" />
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>

--- a/3.1/BlazorSample_WebAssembly/Pages/overwriting-parameters/ExpandersToggle.razor
+++ b/3.1/BlazorSample_WebAssembly/Pages/overwriting-parameters/ExpandersToggle.razor
@@ -1,0 +1,22 @@
+@page "/expanders-toggle"
+
+<PageTitle>Expanders Toggle</PageTitle>
+
+<h1>Expanders Toggle</h1>
+
+<ToggleExpander @bind-Expanded="expanded">
+    Expander content
+</ToggleExpander>
+
+<button @onclick="Toggle">Toggle</button>
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>
+
+@code {
+    private bool expanded;
+
+    private void Toggle()
+    {
+        expanded = !expanded;
+    }
+}

--- a/3.1/BlazorSample_WebAssembly/Shared/overwriting-parameters/BadShowMoreExpander.razor
+++ b/3.1/BlazorSample_WebAssembly/Shared/overwriting-parameters/BadShowMoreExpander.razor
@@ -1,0 +1,24 @@
+<div @onclick="ShowMore" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @InitiallyExpanded)</h2>
+    </div>
+    @if (InitiallyExpanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private void ShowMore()
+    {
+        InitiallyExpanded = true;
+    }
+}

--- a/3.1/BlazorSample_WebAssembly/Shared/overwriting-parameters/ShowMoreExpander.razor
+++ b/3.1/BlazorSample_WebAssembly/Shared/overwriting-parameters/ShowMoreExpander.razor
@@ -1,0 +1,31 @@
+<div @onclick="Expand" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    private bool expanded;
+
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    protected override void OnInitialized()
+    {
+        expanded = InitiallyExpanded;
+    }
+
+    private void Expand()
+    {
+        expanded = true;
+    }
+}

--- a/3.1/BlazorSample_WebAssembly/Shared/overwriting-parameters/ToggleExpander.razor
+++ b/3.1/BlazorSample_WebAssembly/Shared/overwriting-parameters/ToggleExpander.razor
@@ -1,0 +1,35 @@
+<div class="card bg-light mb-3" style="width:30rem">
+    <div @onclick="Toggle" class="card-header">
+        <h2 class="card-title">Toggle (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool Expanded { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> ExpandedChanged { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private bool expanded;
+
+    protected override void OnParametersSet()
+    {
+        expanded = Expanded;
+    }
+
+    private async void Toggle()
+    {
+        expanded = !expanded;
+        await ExpandedChanged.InvokeAsync(expanded);
+    }
+}

--- a/5.0/BlazorSample_Server/Pages/overwriting-parameters/Expanders.razor
+++ b/5.0/BlazorSample_Server/Pages/overwriting-parameters/Expanders.razor
@@ -1,0 +1,13 @@
+@page "/expanders"
+
+<PageTitle>Expanders</PageTitle>
+
+<h1>Expanders Example</h1>
+
+<ShowMoreExpander InitiallyExpanded="false">
+    Expander 1 content
+</ShowMoreExpander>
+
+<ShowMoreExpander InitiallyExpanded="false" />
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>

--- a/5.0/BlazorSample_Server/Pages/overwriting-parameters/ExpandersToggle.razor
+++ b/5.0/BlazorSample_Server/Pages/overwriting-parameters/ExpandersToggle.razor
@@ -1,0 +1,22 @@
+@page "/expanders-toggle"
+
+<PageTitle>Expanders Toggle</PageTitle>
+
+<h1>Expanders Toggle</h1>
+
+<ToggleExpander @bind-Expanded="expanded">
+    Expander content
+</ToggleExpander>
+
+<button @onclick="Toggle">Toggle</button>
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>
+
+@code {
+    private bool expanded;
+
+    private void Toggle()
+    {
+        expanded = !expanded;
+    }
+}

--- a/5.0/BlazorSample_Server/Shared/overwriting-parameters/BadShowMoreExpander.razor
+++ b/5.0/BlazorSample_Server/Shared/overwriting-parameters/BadShowMoreExpander.razor
@@ -1,0 +1,24 @@
+<div @onclick="ShowMore" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @InitiallyExpanded)</h2>
+    </div>
+    @if (InitiallyExpanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private void ShowMore()
+    {
+        InitiallyExpanded = true;
+    }
+}

--- a/5.0/BlazorSample_Server/Shared/overwriting-parameters/ShowMoreExpander.razor
+++ b/5.0/BlazorSample_Server/Shared/overwriting-parameters/ShowMoreExpander.razor
@@ -1,0 +1,31 @@
+<div @onclick="Expand" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    private bool expanded;
+
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    protected override void OnInitialized()
+    {
+        expanded = InitiallyExpanded;
+    }
+
+    private void Expand()
+    {
+        expanded = true;
+    }
+}

--- a/5.0/BlazorSample_Server/Shared/overwriting-parameters/ToggleExpander.razor
+++ b/5.0/BlazorSample_Server/Shared/overwriting-parameters/ToggleExpander.razor
@@ -1,0 +1,35 @@
+<div class="card bg-light mb-3" style="width:30rem">
+    <div @onclick="Toggle" class="card-header">
+        <h2 class="card-title">Toggle (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool Expanded { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> ExpandedChanged { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private bool expanded;
+
+    protected override void OnParametersSet()
+    {
+        expanded = Expanded;
+    }
+
+    private async void Toggle()
+    {
+        expanded = !expanded;
+        await ExpandedChanged.InvokeAsync(expanded);
+    }
+}

--- a/5.0/BlazorSample_WebAssembly/Pages/overwriting-parameters/Expanders.razor
+++ b/5.0/BlazorSample_WebAssembly/Pages/overwriting-parameters/Expanders.razor
@@ -1,0 +1,13 @@
+@page "/expanders"
+
+<PageTitle>Expanders</PageTitle>
+
+<h1>Expanders Example</h1>
+
+<ShowMoreExpander InitiallyExpanded="false">
+    Expander 1 content
+</ShowMoreExpander>
+
+<ShowMoreExpander InitiallyExpanded="false" />
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>

--- a/5.0/BlazorSample_WebAssembly/Pages/overwriting-parameters/ExpandersToggle.razor
+++ b/5.0/BlazorSample_WebAssembly/Pages/overwriting-parameters/ExpandersToggle.razor
@@ -1,0 +1,22 @@
+@page "/expanders-toggle"
+
+<PageTitle>Expanders Toggle</PageTitle>
+
+<h1>Expanders Toggle</h1>
+
+<ToggleExpander @bind-Expanded="expanded">
+    Expander content
+</ToggleExpander>
+
+<button @onclick="Toggle">Toggle</button>
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>
+
+@code {
+    private bool expanded;
+
+    private void Toggle()
+    {
+        expanded = !expanded;
+    }
+}

--- a/5.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/BadShowMoreExpander.razor
+++ b/5.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/BadShowMoreExpander.razor
@@ -1,0 +1,24 @@
+<div @onclick="ShowMore" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @InitiallyExpanded)</h2>
+    </div>
+    @if (InitiallyExpanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private void ShowMore()
+    {
+        InitiallyExpanded = true;
+    }
+}

--- a/5.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/ShowMoreExpander.razor
+++ b/5.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/ShowMoreExpander.razor
@@ -1,0 +1,31 @@
+<div @onclick="Expand" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    private bool expanded;
+
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    protected override void OnInitialized()
+    {
+        expanded = InitiallyExpanded;
+    }
+
+    private void Expand()
+    {
+        expanded = true;
+    }
+}

--- a/5.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/ToggleExpander.razor
+++ b/5.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/ToggleExpander.razor
@@ -1,0 +1,35 @@
+<div class="card bg-light mb-3" style="width:30rem">
+    <div @onclick="Toggle" class="card-header">
+        <h2 class="card-title">Toggle (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool Expanded { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> ExpandedChanged { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private bool expanded;
+
+    protected override void OnParametersSet()
+    {
+        expanded = Expanded;
+    }
+
+    private async void Toggle()
+    {
+        expanded = !expanded;
+        await ExpandedChanged.InvokeAsync(expanded);
+    }
+}

--- a/6.0/BlazorSample_Server/Pages/overwriting-parameters/Expanders.razor
+++ b/6.0/BlazorSample_Server/Pages/overwriting-parameters/Expanders.razor
@@ -1,0 +1,13 @@
+@page "/expanders"
+
+<PageTitle>Expanders</PageTitle>
+
+<h1>Expanders Example</h1>
+
+<ShowMoreExpander InitiallyExpanded="false">
+    Expander 1 content
+</ShowMoreExpander>
+
+<ShowMoreExpander InitiallyExpanded="false" />
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>

--- a/6.0/BlazorSample_Server/Pages/overwriting-parameters/ExpandersToggle.razor
+++ b/6.0/BlazorSample_Server/Pages/overwriting-parameters/ExpandersToggle.razor
@@ -1,0 +1,22 @@
+@page "/expanders-toggle"
+
+<PageTitle>Expanders Toggle</PageTitle>
+
+<h1>Expanders Toggle</h1>
+
+<ToggleExpander @bind-Expanded="expanded">
+    Expander content
+</ToggleExpander>
+
+<button @onclick="Toggle">Toggle</button>
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>
+
+@code {
+    private bool expanded;
+
+    private void Toggle()
+    {
+        expanded = !expanded;
+    }
+}

--- a/6.0/BlazorSample_Server/Shared/overwriting-parameters/BadShowMoreExpander.razor
+++ b/6.0/BlazorSample_Server/Shared/overwriting-parameters/BadShowMoreExpander.razor
@@ -1,0 +1,24 @@
+<div @onclick="ShowMore" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @InitiallyExpanded)</h2>
+    </div>
+    @if (InitiallyExpanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private void ShowMore()
+    {
+        InitiallyExpanded = true;
+    }
+}

--- a/6.0/BlazorSample_Server/Shared/overwriting-parameters/ShowMoreExpander.razor
+++ b/6.0/BlazorSample_Server/Shared/overwriting-parameters/ShowMoreExpander.razor
@@ -1,0 +1,31 @@
+<div @onclick="Expand" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    private bool expanded;
+
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    protected override void OnInitialized()
+    {
+        expanded = InitiallyExpanded;
+    }
+
+    private void Expand()
+    {
+        expanded = true;
+    }
+}

--- a/6.0/BlazorSample_Server/Shared/overwriting-parameters/ToggleExpander.razor
+++ b/6.0/BlazorSample_Server/Shared/overwriting-parameters/ToggleExpander.razor
@@ -1,0 +1,35 @@
+<div class="card bg-light mb-3" style="width:30rem">
+    <div @onclick="Toggle" class="card-header">
+        <h2 class="card-title">Toggle (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool Expanded { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> ExpandedChanged { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private bool expanded;
+
+    protected override void OnParametersSet()
+    {
+        expanded = Expanded;
+    }
+
+    private async void Toggle()
+    {
+        expanded = !expanded;
+        await ExpandedChanged.InvokeAsync(expanded);
+    }
+}

--- a/6.0/BlazorSample_WebAssembly/Pages/overwriting-parameters/Expanders.razor
+++ b/6.0/BlazorSample_WebAssembly/Pages/overwriting-parameters/Expanders.razor
@@ -1,0 +1,13 @@
+@page "/expanders"
+
+<PageTitle>Expanders</PageTitle>
+
+<h1>Expanders Example</h1>
+
+<ShowMoreExpander InitiallyExpanded="false">
+    Expander 1 content
+</ShowMoreExpander>
+
+<ShowMoreExpander InitiallyExpanded="false" />
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>

--- a/6.0/BlazorSample_WebAssembly/Pages/overwriting-parameters/ExpandersToggle.razor
+++ b/6.0/BlazorSample_WebAssembly/Pages/overwriting-parameters/ExpandersToggle.razor
@@ -1,0 +1,22 @@
+@page "/expanders-toggle"
+
+<PageTitle>Expanders Toggle</PageTitle>
+
+<h1>Expanders Toggle</h1>
+
+<ToggleExpander @bind-Expanded="expanded">
+    Expander content
+</ToggleExpander>
+
+<button @onclick="Toggle">Toggle</button>
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>
+
+@code {
+    private bool expanded;
+
+    private void Toggle()
+    {
+        expanded = !expanded;
+    }
+}

--- a/6.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/BadShowMoreExpander.razor
+++ b/6.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/BadShowMoreExpander.razor
@@ -1,0 +1,24 @@
+<div @onclick="ShowMore" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @InitiallyExpanded)</h2>
+    </div>
+    @if (InitiallyExpanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private void ShowMore()
+    {
+        InitiallyExpanded = true;
+    }
+}

--- a/6.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/ShowMoreExpander.razor
+++ b/6.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/ShowMoreExpander.razor
@@ -1,0 +1,31 @@
+<div @onclick="Expand" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    private bool expanded;
+
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    protected override void OnInitialized()
+    {
+        expanded = InitiallyExpanded;
+    }
+
+    private void Expand()
+    {
+        expanded = true;
+    }
+}

--- a/6.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/ToggleExpander.razor
+++ b/6.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/ToggleExpander.razor
@@ -1,0 +1,35 @@
+<div class="card bg-light mb-3" style="width:30rem">
+    <div @onclick="Toggle" class="card-header">
+        <h2 class="card-title">Toggle (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool Expanded { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> ExpandedChanged { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private bool expanded;
+
+    protected override void OnParametersSet()
+    {
+        expanded = Expanded;
+    }
+
+    private async void Toggle()
+    {
+        expanded = !expanded;
+        await ExpandedChanged.InvokeAsync(expanded);
+    }
+}

--- a/7.0/BlazorSample_Server/Pages/overwriting-parameters/Expanders.razor
+++ b/7.0/BlazorSample_Server/Pages/overwriting-parameters/Expanders.razor
@@ -1,0 +1,13 @@
+@page "/expanders"
+
+<PageTitle>Expanders</PageTitle>
+
+<h1>Expanders Example</h1>
+
+<ShowMoreExpander InitiallyExpanded="false">
+    Expander 1 content
+</ShowMoreExpander>
+
+<ShowMoreExpander InitiallyExpanded="false" />
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>

--- a/7.0/BlazorSample_Server/Pages/overwriting-parameters/ExpandersToggle.razor
+++ b/7.0/BlazorSample_Server/Pages/overwriting-parameters/ExpandersToggle.razor
@@ -1,0 +1,22 @@
+@page "/expanders-toggle"
+
+<PageTitle>Expanders Toggle</PageTitle>
+
+<h1>Expanders Toggle</h1>
+
+<ToggleExpander @bind-Expanded="expanded">
+    Expander content
+</ToggleExpander>
+
+<button @onclick="Toggle">Toggle</button>
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>
+
+@code {
+    private bool expanded;
+
+    private void Toggle()
+    {
+        expanded = !expanded;
+    }
+}

--- a/7.0/BlazorSample_Server/Shared/overwriting-parameters/BadShowMoreExpander.razor
+++ b/7.0/BlazorSample_Server/Shared/overwriting-parameters/BadShowMoreExpander.razor
@@ -1,0 +1,24 @@
+<div @onclick="ShowMore" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @InitiallyExpanded)</h2>
+    </div>
+    @if (InitiallyExpanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private void ShowMore()
+    {
+        InitiallyExpanded = true;
+    }
+}

--- a/7.0/BlazorSample_Server/Shared/overwriting-parameters/ShowMoreExpander.razor
+++ b/7.0/BlazorSample_Server/Shared/overwriting-parameters/ShowMoreExpander.razor
@@ -1,0 +1,31 @@
+<div @onclick="Expand" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    private bool expanded;
+
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    protected override void OnInitialized()
+    {
+        expanded = InitiallyExpanded;
+    }
+
+    private void Expand()
+    {
+        expanded = true;
+    }
+}

--- a/7.0/BlazorSample_Server/Shared/overwriting-parameters/ToggleExpander.razor
+++ b/7.0/BlazorSample_Server/Shared/overwriting-parameters/ToggleExpander.razor
@@ -1,0 +1,35 @@
+<div class="card bg-light mb-3" style="width:30rem">
+    <div @onclick="Toggle" class="card-header">
+        <h2 class="card-title">Toggle (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool Expanded { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> ExpandedChanged { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private bool expanded;
+
+    protected override void OnParametersSet()
+    {
+        expanded = Expanded;
+    }
+
+    private async void Toggle()
+    {
+        expanded = !expanded;
+        await ExpandedChanged.InvokeAsync(expanded);
+    }
+}

--- a/7.0/BlazorSample_WebAssembly/Pages/overwriting-parameters/Expanders.razor
+++ b/7.0/BlazorSample_WebAssembly/Pages/overwriting-parameters/Expanders.razor
@@ -1,0 +1,13 @@
+@page "/expanders"
+
+<PageTitle>Expanders</PageTitle>
+
+<h1>Expanders Example</h1>
+
+<ShowMoreExpander InitiallyExpanded="false">
+    Expander 1 content
+</ShowMoreExpander>
+
+<ShowMoreExpander InitiallyExpanded="false" />
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>

--- a/7.0/BlazorSample_WebAssembly/Pages/overwriting-parameters/ExpandersToggle.razor
+++ b/7.0/BlazorSample_WebAssembly/Pages/overwriting-parameters/ExpandersToggle.razor
@@ -1,0 +1,22 @@
+@page "/expanders-toggle"
+
+<PageTitle>Expanders Toggle</PageTitle>
+
+<h1>Expanders Toggle</h1>
+
+<ToggleExpander @bind-Expanded="expanded">
+    Expander content
+</ToggleExpander>
+
+<button @onclick="Toggle">Toggle</button>
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>
+
+@code {
+    private bool expanded;
+
+    private void Toggle()
+    {
+        expanded = !expanded;
+    }
+}

--- a/7.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/BadShowMoreExpander.razor
+++ b/7.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/BadShowMoreExpander.razor
@@ -1,0 +1,24 @@
+<div @onclick="ShowMore" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @InitiallyExpanded)</h2>
+    </div>
+    @if (InitiallyExpanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private void ShowMore()
+    {
+        InitiallyExpanded = true;
+    }
+}

--- a/7.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/ShowMoreExpander.razor
+++ b/7.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/ShowMoreExpander.razor
@@ -1,0 +1,31 @@
+<div @onclick="Expand" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    private bool expanded;
+
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    protected override void OnInitialized()
+    {
+        expanded = InitiallyExpanded;
+    }
+
+    private void Expand()
+    {
+        expanded = true;
+    }
+}

--- a/7.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/ToggleExpander.razor
+++ b/7.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/ToggleExpander.razor
@@ -1,0 +1,35 @@
+<div class="card bg-light mb-3" style="width:30rem">
+    <div @onclick="Toggle" class="card-header">
+        <h2 class="card-title">Toggle (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool Expanded { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> ExpandedChanged { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private bool expanded;
+
+    protected override void OnParametersSet()
+    {
+        expanded = Expanded;
+    }
+
+    private async void Toggle()
+    {
+        expanded = !expanded;
+        await ExpandedChanged.InvokeAsync(expanded);
+    }
+}

--- a/8.0/BlazorSample_BlazorWebApp/Components/Pages/Expanders.razor
+++ b/8.0/BlazorSample_BlazorWebApp/Components/Pages/Expanders.razor
@@ -1,8 +1,8 @@
-@page "/expander"
+@page "/expanders"
 
-<PageTitle>Expander</PageTitle>
+<PageTitle>Expanders</PageTitle>
 
-<h1>Expander Example</h1>
+<h1>Expanders Example</h1>
 
 <ShowMoreExpander InitiallyExpanded="false">
     Expander 1 content

--- a/8.0/BlazorSample_BlazorWebApp/Components/Pages/ExpandersToggle.razor
+++ b/8.0/BlazorSample_BlazorWebApp/Components/Pages/ExpandersToggle.razor
@@ -1,8 +1,8 @@
-@page "/expander-toggle"
+@page "/expanders-toggle"
 
-<PageTitle>Expander</PageTitle>
+<PageTitle>Expanders Toggle</PageTitle>
 
-<h1>Expander Toggle</h1>
+<h1>Expanders Toggle</h1>
 
 <ToggleExpander @bind-Expanded="expanded">
     Expander content

--- a/8.0/BlazorSample_WebAssembly/Pages/Expanders.razor
+++ b/8.0/BlazorSample_WebAssembly/Pages/Expanders.razor
@@ -1,0 +1,13 @@
+@page "/expanders"
+
+<PageTitle>Expanders</PageTitle>
+
+<h1>Expanders Example</h1>
+
+<ShowMoreExpander InitiallyExpanded="false">
+    Expander 1 content
+</ShowMoreExpander>
+
+<ShowMoreExpander InitiallyExpanded="false" />
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>

--- a/8.0/BlazorSample_WebAssembly/Pages/ExpandersToggle.razor
+++ b/8.0/BlazorSample_WebAssembly/Pages/ExpandersToggle.razor
@@ -1,0 +1,22 @@
+@page "/expanders-toggle"
+
+<PageTitle>Expanders Toggle</PageTitle>
+
+<h1>Expanders Toggle</h1>
+
+<ToggleExpander @bind-Expanded="expanded">
+    Expander content
+</ToggleExpander>
+
+<button @onclick="Toggle">Toggle</button>
+
+<button @onclick="StateHasChanged">Call StateHasChanged</button>
+
+@code {
+    private bool expanded;
+
+    private void Toggle()
+    {
+        expanded = !expanded;
+    }
+}

--- a/8.0/BlazorSample_WebAssembly/Shared/BadShowMoreExpander.razor
+++ b/8.0/BlazorSample_WebAssembly/Shared/BadShowMoreExpander.razor
@@ -1,0 +1,24 @@
+<div @onclick="ShowMore" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @InitiallyExpanded)</h2>
+    </div>
+    @if (InitiallyExpanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private void ShowMore()
+    {
+        InitiallyExpanded = true;
+    }
+}

--- a/8.0/BlazorSample_WebAssembly/Shared/ShowMoreExpander.razor
+++ b/8.0/BlazorSample_WebAssembly/Shared/ShowMoreExpander.razor
@@ -1,0 +1,31 @@
+<div @onclick="Expand" class="card bg-light mb-3" style="width:30rem">
+    <div class="card-header">
+        <h2 class="card-title">Show more (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    private bool expanded;
+
+    [Parameter]
+    public bool InitiallyExpanded { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    protected override void OnInitialized()
+    {
+        expanded = InitiallyExpanded;
+    }
+
+    private void Expand()
+    {
+        expanded = true;
+    }
+}

--- a/8.0/BlazorSample_WebAssembly/Shared/ToggleExpander.razor
+++ b/8.0/BlazorSample_WebAssembly/Shared/ToggleExpander.razor
@@ -1,0 +1,35 @@
+<div class="card bg-light mb-3" style="width:30rem">
+    <div @onclick="Toggle" class="card-header">
+        <h2 class="card-title">Toggle (<code>Expanded</code> = @expanded)</h2>
+    </div>
+    @if (expanded)
+    {
+        <div class="card-body">
+            <p class="card-text">@ChildContent</p>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public bool Expanded { get; set; }
+
+    [Parameter]
+    public EventCallback<bool> ExpandedChanged { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    private bool expanded;
+
+    protected override void OnParametersSet()
+    {
+        expanded = Expanded;
+    }
+
+    private async void Toggle()
+    {
+        expanded = !expanded;
+        await ExpandedChanged.InvokeAsync(expanded);
+    }
+}


### PR DESCRIPTION
continuation of #214 

* renamed the pages to `Expanders.razor` + `ExpandersToggle.razor` to distinguish from individual components
* added other platforms

cc @guardrex 