### PR TITLE
Expanders - no PageTitle component prior to net6

### DIFF
--- a/3.1/BlazorSample_Server/Pages/overwriting-parameters/Expanders.razor
+++ b/3.1/BlazorSample_Server/Pages/overwriting-parameters/Expanders.razor
@@ -1,7 +1,5 @@
 @page "/expanders"
 
-<PageTitle>Expanders</PageTitle>
-
 <h1>Expanders Example</h1>
 
 <ShowMoreExpander InitiallyExpanded="false">

--- a/3.1/BlazorSample_Server/Pages/overwriting-parameters/ExpandersToggle.razor
+++ b/3.1/BlazorSample_Server/Pages/overwriting-parameters/ExpandersToggle.razor
@@ -1,7 +1,5 @@
 @page "/expanders-toggle"
 
-<PageTitle>Expanders Toggle</PageTitle>
-
 <h1>Expanders Toggle</h1>
 
 <ToggleExpander @bind-Expanded="expanded">

--- a/3.1/BlazorSample_WebAssembly/Pages/overwriting-parameters/Expanders.razor
+++ b/3.1/BlazorSample_WebAssembly/Pages/overwriting-parameters/Expanders.razor
@@ -1,7 +1,5 @@
 @page "/expanders"
 
-<PageTitle>Expanders</PageTitle>
-
 <h1>Expanders Example</h1>
 
 <ShowMoreExpander InitiallyExpanded="false">

--- a/3.1/BlazorSample_WebAssembly/Pages/overwriting-parameters/ExpandersToggle.razor
+++ b/3.1/BlazorSample_WebAssembly/Pages/overwriting-parameters/ExpandersToggle.razor
@@ -1,7 +1,5 @@
 @page "/expanders-toggle"
 
-<PageTitle>Expanders Toggle</PageTitle>
-
 <h1>Expanders Toggle</h1>
 
 <ToggleExpander @bind-Expanded="expanded">

--- a/5.0/BlazorSample_Server/Pages/overwriting-parameters/Expanders.razor
+++ b/5.0/BlazorSample_Server/Pages/overwriting-parameters/Expanders.razor
@@ -1,7 +1,5 @@
 @page "/expanders"
 
-<PageTitle>Expanders</PageTitle>
-
 <h1>Expanders Example</h1>
 
 <ShowMoreExpander InitiallyExpanded="false">

--- a/5.0/BlazorSample_Server/Pages/overwriting-parameters/ExpandersToggle.razor
+++ b/5.0/BlazorSample_Server/Pages/overwriting-parameters/ExpandersToggle.razor
@@ -1,7 +1,5 @@
 @page "/expanders-toggle"
 
-<PageTitle>Expanders Toggle</PageTitle>
-
 <h1>Expanders Toggle</h1>
 
 <ToggleExpander @bind-Expanded="expanded">

--- a/5.0/BlazorSample_WebAssembly/Pages/overwriting-parameters/Expanders.razor
+++ b/5.0/BlazorSample_WebAssembly/Pages/overwriting-parameters/Expanders.razor
@@ -1,7 +1,5 @@
 @page "/expanders"
 
-<PageTitle>Expanders</PageTitle>
-
 <h1>Expanders Example</h1>
 
 <ShowMoreExpander InitiallyExpanded="false">

--- a/5.0/BlazorSample_WebAssembly/Pages/overwriting-parameters/ExpandersToggle.razor
+++ b/5.0/BlazorSample_WebAssembly/Pages/overwriting-parameters/ExpandersToggle.razor
@@ -1,7 +1,5 @@
 @page "/expanders-toggle"
 
-<PageTitle>Expanders Toggle</PageTitle>
-
 <h1>Expanders Toggle</h1>
 
 <ToggleExpander @bind-Expanded="expanded">


### PR DESCRIPTION
Fix for warnings found by the new CI build :-D

cc @guardrex 