### PR TITLE
Fix IDX21323: RequireNonce is 'False' during token refreshClient

### DIFF
--- a/8.0/BlazorWebAppOidc/BlazorWebAppOidc/CookieOidcRefresher.cs
+++ b/8.0/BlazorWebAppOidc/BlazorWebAppOidc/CookieOidcRefresher.cs
@@ -9,7 +9,7 @@ using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 
-namespace BlazorWebOidc;
+namespace BlazorWebAppOidc;
 
 // https://github.com/dotnet/aspnetcore/issues/8175
 internal sealed class CookieOidcRefresher(IOptionsMonitor<OpenIdConnectOptions> oidcOptionsMonitor)

--- a/8.0/BlazorWebAppOidcBff/BlazorWebAppOidc/CookieOidcRefresher.cs
+++ b/8.0/BlazorWebAppOidcBff/BlazorWebAppOidc/CookieOidcRefresher.cs
@@ -9,7 +9,7 @@ using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 
-namespace BlazorWebOidc;
+namespace BlazorWebAppOidc;
 
 // https://github.com/dotnet/aspnetcore/issues/8175
 internal sealed class CookieOidcRefresher(IOptionsMonitor<OpenIdConnectOptions> oidcOptionsMonitor)


### PR DESCRIPTION
See https://security.stackexchange.com/questions/147529/openid-connect-nonce-replay-attack and https://github.com/IdentityServer/IdentityServer4/issues/2180 for the purpose of the nonce and why it's unnecessary for the token refresh.

This also switches to using `OpenIdConnectOptions.Backchannel` rather than its own `HttpClient` so it gets [an OIDC-specific user agent](https://github.com/dotnet/aspnetcore/blob/b3b8dffff4d092058b2d8942268b498cbfdb14ec/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectPostConfigureOptions.cs#L71) and includes any other customizations that might be necessary for communicating with the given OIDC provider.

Fixes https://github.com/dotnet/aspnetcore/issues/53585