### PR TITLE
BWAOidcBFF solution package updates

### DIFF
--- a/8.0/BlazorWebAppOidc/BlazorWebAppOidc.Client/BlazorWebAppOidc.Client.csproj
+++ b/8.0/BlazorWebAppOidc/BlazorWebAppOidc.Client/BlazorWebAppOidc.Client.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
   </ItemGroup>
 

--- a/8.0/BlazorWebAppOidc/BlazorWebAppOidc/BlazorWebAppOidc.csproj
+++ b/8.0/BlazorWebAppOidc/BlazorWebAppOidc/BlazorWebAppOidc.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\BlazorWebAppOidc.Client\BlazorWebAppOidc.Client.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/8.0/BlazorWebAppOidcBff/Aspire/Aspire.AppHost/Aspire.AppHost.csproj
+++ b/8.0/BlazorWebAppOidcBff/Aspire/Aspire.AppHost/Aspire.AppHost.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" Version="8.0.0-preview.1.23557.2" />
+    <PackageReference Include="Aspire.Hosting" Version="8.0.0-preview.4.24156.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/8.0/BlazorWebAppOidcBff/Aspire/Aspire.ServiceDefaults/Aspire.ServiceDefaults.csproj
+++ b/8.0/BlazorWebAppOidcBff/Aspire/Aspire.ServiceDefaults/Aspire.ServiceDefaults.csproj
@@ -11,13 +11,13 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.1.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.1.23557.2" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.3.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.4.24156.9" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.7.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.7.0" />
   </ItemGroup>
 

--- a/8.0/BlazorWebAppOidcBff/BlazorWebAppOidc.Client/BlazorWebAppOidc.Client.csproj
+++ b/8.0/BlazorWebAppOidcBff/BlazorWebAppOidc.Client/BlazorWebAppOidc.Client.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
   </ItemGroup>
 

--- a/8.0/BlazorWebAppOidcBff/BlazorWebAppOidc/BlazorWebAppOidc.csproj
+++ b/8.0/BlazorWebAppOidcBff/BlazorWebAppOidc/BlazorWebAppOidc.csproj
@@ -9,9 +9,9 @@
   <ItemGroup>
     <ProjectReference Include="..\Aspire\Aspire.ServiceDefaults\Aspire.ServiceDefaults.csproj" />
     <ProjectReference Include="..\BlazorWebAppOidc.Client\BlazorWebAppOidc.Client.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="8.0.0-preview.1.23557.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="8.0.0-preview.4.24156.9" />
   </ItemGroup>
 
 </Project>

--- a/8.0/BlazorWebAppOidcBff/MinimalApiJwt/MinimalApiJwt.csproj
+++ b/8.0/BlazorWebAppOidcBff/MinimalApiJwt/MinimalApiJwt.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Aspire\Aspire.ServiceDefaults\Aspire.ServiceDefaults.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/8.0/BlazorWebAppOidcBff/README.md
+++ b/8.0/BlazorWebAppOidcBff/README.md
@@ -13,7 +13,7 @@ This sample features:
 
 ## Configure the sample
 
-Configure the OIDC provider using the comments in the Program.cs file.
+Configure the OIDC provider using the comments in the Program.cs file and guidance in [Secure an ASP.NET Core Blazor Web App with OpenID Connect (OIDC)](https://learn.microsoft.com/aspnet/core/blazor/security/blazor-web-app-with-oidc?view=aspnetcore-8.0&pivots=with-bff-pattern).
 
 ## Run the sample
 


### PR DESCRIPTION
Fixes #245

Thanks @cipherw0lf ... It's not clear from your issue if you configured everything properly to run, but I found several updates to make ...

* These had patch ASP.NET Core packages (8.0.1), but we normally just let the roll-forward patches take effect on their own. Therefore, I switched them to 8.0.0. Whatever the latest patch release, they will be consumed automatically.
* These projects had older preview and non-preview packages. I've updated those to the latest.

WRT the starting project, the guidance is correct in its present form. The solution should be started from the `Aspire/Aspire.AppHost` project.