### PR TITLE
Add scope guidance based on tenant type

### DIFF
--- a/8.0/BlazorWebAppOidcBff/BlazorWebAppOidc/Program.cs
+++ b/8.0/BlazorWebAppOidcBff/BlazorWebAppOidc/Program.cs
@@ -46,7 +46,7 @@ builder.Services.AddAuthentication("MicrosoftOidc")
         // values are "/signin-oidc" and "/signout-callback-oidc".
         // Microsoft Identity currently only redirects back to the 
         // SignedOutCallbackPath if authority is 
-        // https://login.microsoftonline.com/{TENANT ID}/v2.0/ as it is above. 
+        // https://login.microsoftonline.com/{TENANT ID}/v2.0/ as it is below. 
         // You can use the "common" authority instead, and logout redirects back to 
         // the Blazor app. For more information, see 
         // https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/5783
@@ -65,7 +65,13 @@ builder.Services.AddAuthentication("MicrosoftOidc")
         // ........................................................................
         // The "Weather.Get" scope is configured in the Azure or Entra portal under 
         // "Expose an API". This is necessary for backend web API (MinimalApiJwt)
-        // to validate the access token with AddBearerJwt.
+        // to validate the access token with AddBearerJwt. The following code example
+        // uses a scope format of the App ID URI for an AAD B2C tenant type. If your
+        // tenant is an ME-ID tenant, the App ID URI format is different:
+        // api://{CLIENT ID}, so the full scope with an API name of "Weather.Get" is:
+        // api://{CLIENT ID}/Weather.Get
+        // The {CLIENT ID} is the application (client) ID of the MinimalApiJwt app 
+        // registration.
 
         oidcOptions.Scope.Add("https://{DIRECTORY NAME}.onmicrosoft.com/{CLIENT ID}/Weather.Get");
         // ........................................................................

--- a/8.0/BlazorWebAppOidcBff/MinimalApiJwt/Program.cs
+++ b/8.0/BlazorWebAppOidcBff/MinimalApiJwt/Program.cs
@@ -6,11 +6,14 @@ builder.AddServiceDefaults();
 builder.Services.AddAuthentication()
     .AddJwtBearer("Bearer", jwtOptions =>
     {
-        // This should match the authority configured for the OIDC handler in BlazorWebAppOidc/Program.cs.
-        jwtOptions.Authority = "https://login.microsoftonline.com/{tenant-id}/v2.0/";
-        // This should match just the path of the Application ID URI configured when adding the "Weather.Get" scope
-        // under "Expose an API" in the Azure or Entra portal.
-        jwtOptions.Audience = "{client-id}";
+        // The following should match the authority configured for the OIDC handler in BlazorWebAppOidc/Program.cs.
+        // {TENANT ID} is the directory (tenant) ID.
+        jwtOptions.Authority = "https://login.microsoftonline.com/{TENANT ID}/v2.0/";
+        // The following should match just the path of the Application ID URI configured when adding the "Weather.Get" scope
+        // under "Expose an API" in the Azure or Entra portal. {CLIENT ID} is the application (client) ID of this 
+        // app's registration in the Azure portal. If using an ME-ID tenant type, the format of the App ID URI is:
+        // api://{CLIENT ID}
+        jwtOptions.Audience = "https://{DIRECTORY NAME}.onmicrosoft.com/{CLIENT ID}";
     });
 builder.Services.AddAuthorization();
 


### PR DESCRIPTION
Fixes #251

Thanks @swegele .... I didn't conclude that the `sts.windows.net` address for the authority was correct. I'm not sure how that figures into the general explanation. I thought that the authority should remain as Stephen Halter specified it here. What I do here is update the code comments to distinguish between the scope values for an ME-ID tenant versus an AAD B2C tenant. It looks like Halter was using a B2C tenant, and I'm familiar from other work with Azure on your use of an ME-ID tenant type (e.g., `api://{CLIENT ID}` App ID URI.

I'll take up changes to mirror these updates in the article next.