### PR TITLE
Add remark on ME-ID authority in server API config

### DIFF
--- a/8.0/BlazorWebAppOidcBff/MinimalApiJwt/Program.cs
+++ b/8.0/BlazorWebAppOidcBff/MinimalApiJwt/Program.cs
@@ -7,7 +7,9 @@ builder.Services.AddAuthentication()
     .AddJwtBearer("Bearer", jwtOptions =>
     {
         // The following should match the authority configured for the OIDC handler in BlazorWebAppOidc/Program.cs.
-        // {TENANT ID} is the directory (tenant) ID.
+        // {TENANT ID} is the directory (tenant) ID. If using an ME-ID tenant type, the authority should match
+        // the issurer (`iss`) of the JWT returned by the identity provider:
+        // https://sts.windows.net/{TENANT ID}/
         jwtOptions.Authority = "https://login.microsoftonline.com/{TENANT ID}/v2.0/";
         // The following should match just the path of the Application ID URI configured when adding the "Weather.Get" scope
         // under "Expose an API" in the Azure or Entra portal. {CLIENT ID} is the application (client) ID of this 


### PR DESCRIPTION
Fixes #251 

I'm definitely going to repro the whole setup ***BOTH*** ways ... with an AAD B2C tenant, which is what Halter was using, and an ME-ID tenant. For now, I'm just going to call this out here in the code comment and over on a different PR for the article.