### PR TITLE
DynamicComponent1 - vulnerability fix

### DIFF
--- a/8.0/BlazorSample_BlazorWebApp/Components/Pages/DynamicComponent1.razor
+++ b/8.0/BlazorSample_BlazorWebApp/Components/Pages/DynamicComponent1.razor
@@ -9,10 +9,10 @@
         Select your transport:
         <select @onchange="OnDropdownChange">
             <option value="">Select a value</option>
-            <option value="@nameof(RocketLab)">Rocket Lab</option>
-            <option value="@nameof(SpaceX)">SpaceX</option>
-            <option value="@nameof(UnitedLaunchAlliance)">ULA</option>
-            <option value="@nameof(VirginGalactic)">Virgin Galactic</option>
+			@foreach (var entry in components.Keys)
+			{
+				<option value="@entry">@entry</option>
+			}
         </select>
     </label>
 </p>
@@ -25,16 +25,24 @@
 }
 
 @code {
-    private Type? selectedType;
-
-    private void OnDropdownChange(ChangeEventArgs e)
+	private readonly Dictionary<string, Type> components = new()
     {
-        /*
-            IMPORTANT!
-            Change "BlazorSample.Components" to match 
-            your shared component's namespace in the Type.GetType() argument.
-        */
-        selectedType = e.Value?.ToString()?.Length > 0 ? 
-            Type.GetType($"BlazorSample.Components.{e.Value}") : null;
-    }
+        { "Rocket Lab", typeof(RocketLab) },
+        { "SpaceX", typeof(SpaceX) },
+        { "ULA", typeof(UnitedLaunchAlliance) },
+        { "Virgin Galactic", typeof(VirginGalactic) }
+    };
+	private Type? selectedType;
+
+	private void OnDropdownChange(ChangeEventArgs e)
+	{
+		if (e.Value is string dropdownValue && !String.IsNullOrWhiteSpace(dropdownValue))
+		{
+			selectedType = components[dropdownValue];
+		}
+		else
+		{
+			selectedType = null;
+		}
+	}
 }


### PR DESCRIPTION
I believe this code is vulnerable to an injection attack. You should never use user input to directly execute code.

```csharp
selectedType = e.Value?.ToString()?.Length > 0 ? 
    Type.GetType($"BlazorSample.Components.{e.Value}") : null;
```

The combination of `Type.GetType()` and user input `e.Value` effectively allows referencing (and thus executing) "any" type (within the namespace).

For instance, by manipulating the DOM in the browser, such as adding `<option value="PrivateComponent">...</option>` and triggering the `select.change` event, it's possible to instantiate and render `BlazorSample.Components.PrivateComponent`. This is particularly concerning in the context of Blazor Server, where `PrivateComponent` might execute code or expose data that shouldn't be accessible to the user (unlike in Blazor WASM, where it's not intended to "protect secrets").

If you agree, I will update all the vulnerable examples accordingly and adjust the text describing the example on the [Dynamically-rendered ASP.NET Core Razor components | Microsoft Learn](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/dynamiccomponent?view=aspnetcore-8.0) page.

cc @guardrex 