### PR TITLE
Remove pointless region from Program.cs

### DIFF
--- a/8.0/BlazorWebAppEFCore/Program.cs
+++ b/8.0/BlazorWebAppEFCore/Program.cs
@@ -9,10 +9,8 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
 // Register factory and configure the options
-#region snippet1
 builder.Services.AddDbContextFactory<ContactContext>(opt =>
     opt.UseSqlite($"Data Source={nameof(ContactContext.ContactsDb)}.db"));
-#endregion
 
 // Pager
 builder.Services.AddScoped<IPageHelper, PageHelper>();

--- a/8.0/BlazorWebAppEFCore/Program.cs
+++ b/8.0/BlazorWebAppEFCore/Program.cs
@@ -9,8 +9,10 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 
 // Register factory and configure the options
+// <snippet1>
 builder.Services.AddDbContextFactory<ContactContext>(opt =>
     opt.UseSqlite($"Data Source={nameof(ContactContext.ContactsDb)}.db"));
+// </snippet1>
 
 // Pager
 builder.Services.AddScoped<IPageHelper, PageHelper>();


### PR DESCRIPTION
For some reason, this call to AddDbContextFactory is inside a region (folded by default in some editors, e.g. VS2022)

Given that this is the only example for setting up this context factory (not included here: https://learn.microsoft.com/en-us/aspnet/core/blazor/blazor-ef-core?view=aspnetcore-8.0#sample-app), obscuring this seems like a bad idea. (Don't ask me how much time I just spent searching for where the factory was coming from...)