### PR TITLE
Expanders - nullable annotations removal in net5 & net31

### DIFF
--- a/3.1/BlazorSample_Server/Shared/overwriting-parameters/BadShowMoreExpander.razor
+++ b/3.1/BlazorSample_Server/Shared/overwriting-parameters/BadShowMoreExpander.razor
@@ -15,7 +15,7 @@
     public bool InitiallyExpanded { get; set; }
 
     [Parameter]
-    public RenderFragment? ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     private void ShowMore()
     {

--- a/3.1/BlazorSample_Server/Shared/overwriting-parameters/ShowMoreExpander.razor
+++ b/3.1/BlazorSample_Server/Shared/overwriting-parameters/ShowMoreExpander.razor
@@ -17,7 +17,7 @@
     public bool InitiallyExpanded { get; set; }
 
     [Parameter]
-    public RenderFragment? ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     protected override void OnInitialized()
     {

--- a/3.1/BlazorSample_Server/Shared/overwriting-parameters/ToggleExpander.razor
+++ b/3.1/BlazorSample_Server/Shared/overwriting-parameters/ToggleExpander.razor
@@ -18,7 +18,7 @@
     public EventCallback<bool> ExpandedChanged { get; set; }
 
     [Parameter]
-    public RenderFragment? ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     private bool expanded;
 

--- a/3.1/BlazorSample_WebAssembly/Shared/overwriting-parameters/BadShowMoreExpander.razor
+++ b/3.1/BlazorSample_WebAssembly/Shared/overwriting-parameters/BadShowMoreExpander.razor
@@ -15,7 +15,7 @@
     public bool InitiallyExpanded { get; set; }
 
     [Parameter]
-    public RenderFragment? ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     private void ShowMore()
     {

--- a/3.1/BlazorSample_WebAssembly/Shared/overwriting-parameters/ShowMoreExpander.razor
+++ b/3.1/BlazorSample_WebAssembly/Shared/overwriting-parameters/ShowMoreExpander.razor
@@ -17,7 +17,7 @@
     public bool InitiallyExpanded { get; set; }
 
     [Parameter]
-    public RenderFragment? ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     protected override void OnInitialized()
     {

--- a/3.1/BlazorSample_WebAssembly/Shared/overwriting-parameters/ToggleExpander.razor
+++ b/3.1/BlazorSample_WebAssembly/Shared/overwriting-parameters/ToggleExpander.razor
@@ -18,7 +18,7 @@
     public EventCallback<bool> ExpandedChanged { get; set; }
 
     [Parameter]
-    public RenderFragment? ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     private bool expanded;
 

--- a/5.0/BlazorSample_Server/Shared/overwriting-parameters/BadShowMoreExpander.razor
+++ b/5.0/BlazorSample_Server/Shared/overwriting-parameters/BadShowMoreExpander.razor
@@ -15,7 +15,7 @@
     public bool InitiallyExpanded { get; set; }
 
     [Parameter]
-    public RenderFragment? ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     private void ShowMore()
     {

--- a/5.0/BlazorSample_Server/Shared/overwriting-parameters/ShowMoreExpander.razor
+++ b/5.0/BlazorSample_Server/Shared/overwriting-parameters/ShowMoreExpander.razor
@@ -17,7 +17,7 @@
     public bool InitiallyExpanded { get; set; }
 
     [Parameter]
-    public RenderFragment? ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     protected override void OnInitialized()
     {

--- a/5.0/BlazorSample_Server/Shared/overwriting-parameters/ToggleExpander.razor
+++ b/5.0/BlazorSample_Server/Shared/overwriting-parameters/ToggleExpander.razor
@@ -18,7 +18,7 @@
     public EventCallback<bool> ExpandedChanged { get; set; }
 
     [Parameter]
-    public RenderFragment? ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     private bool expanded;
 

--- a/5.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/BadShowMoreExpander.razor
+++ b/5.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/BadShowMoreExpander.razor
@@ -15,7 +15,7 @@
     public bool InitiallyExpanded { get; set; }
 
     [Parameter]
-    public RenderFragment? ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     private void ShowMore()
     {

--- a/5.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/ShowMoreExpander.razor
+++ b/5.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/ShowMoreExpander.razor
@@ -17,7 +17,7 @@
     public bool InitiallyExpanded { get; set; }
 
     [Parameter]
-    public RenderFragment? ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     protected override void OnInitialized()
     {

--- a/5.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/ToggleExpander.razor
+++ b/5.0/BlazorSample_WebAssembly/Shared/overwriting-parameters/ToggleExpander.razor
@@ -18,7 +18,7 @@
     public EventCallback<bool> ExpandedChanged { get; set; }
 
     [Parameter]
-    public RenderFragment? ChildContent { get; set; }
+    public RenderFragment ChildContent { get; set; }
 
     private bool expanded;
 


### PR DESCRIPTION
build warnings
there were no nullable annotations in net5 & net31
feature downgrade for unsupported frameworks 😭
low prio

cc @guardrex 