### PR TITLE
Improve handling of KeyedService in Transient Disposables detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ _site/
 !.vscode/extensions.json
 !.vscode/settings.json
 *.userprefs
+.idea/
 
 # Build results
 [Dd]ebug/

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ _site/
 !.vscode/extensions.json
 !.vscode/settings.json
 *.userprefs
-.idea/
 
 # Build results
 [Dd]ebug/

--- a/8.0/BlazorSample_BlazorWebApp/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/8.0/BlazorSample_BlazorWebApp/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -47,14 +47,19 @@ namespace BlazorServerTransientDisposable
             foreach (var descriptor in containerBuilder)
             {
                 if (descriptor.Lifetime == ServiceLifetime.Transient &&
-                    descriptor.ImplementationType != null && 
+                    ((!descriptor.IsKeyedService && descriptor.ImplementationType != null && 
                     typeof(IDisposable).IsAssignableFrom(
                         descriptor.ImplementationType))
+                        || (descriptor.IsKeyedService && descriptor.KeyedImplementationType != null && 
+                    typeof(IDisposable).IsAssignableFrom(
+                        descriptor.KeyedImplementationType)))
+                )
                 {
                     collection.Add(CreatePatchedDescriptor(descriptor));
                 }
                 else if (descriptor.Lifetime == ServiceLifetime.Transient &&
-                         descriptor.ImplementationFactory != null)
+                         ((!descriptor.IsKeyedService && descriptor.ImplementationFactory != null)
+                         || (descriptor.IsKeyedService && descriptor.KeyedImplementationFactory != null)))
                 {
                     collection.Add(CreatePatchedFactoryDescriptor(descriptor));
                 }

--- a/8.0/BlazorSample_WebAssembly/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/8.0/BlazorSample_WebAssembly/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -44,14 +44,19 @@ namespace BlazorWebAssemblyTransientDisposable
             foreach (var descriptor in containerBuilder)
             {
                 if (descriptor.Lifetime == ServiceLifetime.Transient &&
-                    descriptor.ImplementationType != null &&
-                    typeof(IDisposable).IsAssignableFrom(
-                        descriptor.ImplementationType))
+                    ((!descriptor.IsKeyedService && descriptor.ImplementationType != null && 
+                      typeof(IDisposable).IsAssignableFrom(
+                          descriptor.ImplementationType))
+                     || (descriptor.IsKeyedService && descriptor.KeyedImplementationType != null && 
+                         typeof(IDisposable).IsAssignableFrom(
+                             descriptor.KeyedImplementationType)))
+                   )
                 {
                     collection.Add(CreatePatchedDescriptor(descriptor));
                 }
                 else if (descriptor.Lifetime == ServiceLifetime.Transient &&
-                         descriptor.ImplementationFactory != null)
+                         ((!descriptor.IsKeyedService && descriptor.ImplementationFactory != null)
+                          || (descriptor.IsKeyedService && descriptor.KeyedImplementationFactory != null)))
                 {
                     collection.Add(CreatePatchedFactoryDescriptor(descriptor));
                 }

--- a/8.0/BlazorSample_WebAssembly/DetectIncorrectUsagesOfTransientDisposables.cs
+++ b/8.0/BlazorSample_WebAssembly/DetectIncorrectUsagesOfTransientDisposables.cs
@@ -43,26 +43,23 @@ namespace BlazorWebAssemblyTransientDisposable
 
             foreach (var descriptor in containerBuilder)
             {
-                if (descriptor.Lifetime == ServiceLifetime.Transient &&
-                    ((!descriptor.IsKeyedService && descriptor.ImplementationType != null && 
-                      typeof(IDisposable).IsAssignableFrom(
-                          descriptor.ImplementationType))
-                     || (descriptor.IsKeyedService && descriptor.KeyedImplementationType != null && 
-                         typeof(IDisposable).IsAssignableFrom(
-                             descriptor.KeyedImplementationType)))
-                   )
+                switch (descriptor.Lifetime)
                 {
-                    collection.Add(CreatePatchedDescriptor(descriptor));
-                }
-                else if (descriptor.Lifetime == ServiceLifetime.Transient &&
-                         ((!descriptor.IsKeyedService && descriptor.ImplementationFactory != null)
-                          || (descriptor.IsKeyedService && descriptor.KeyedImplementationFactory != null)))
-                {
-                    collection.Add(CreatePatchedFactoryDescriptor(descriptor));
-                }
-                else
-                {
-                    collection.Add(descriptor);
+                    case ServiceLifetime.Transient 
+                        when (descriptor is { IsKeyedService: true, KeyedImplementationType: not null }
+                            && typeof(IDisposable).IsAssignableFrom(descriptor.KeyedImplementationType))
+                            || (descriptor is { IsKeyedService: false, ImplementationType: not null }
+                                && typeof(IDisposable).IsAssignableFrom(descriptor.ImplementationType)):
+                        collection.Add(CreatePatchedDescriptor(descriptor));
+                        break;
+                    case ServiceLifetime.Transient
+                        when descriptor is { IsKeyedService: true, KeyedImplementationFactory: not null }
+                            or { IsKeyedService: false, ImplementationFactory: not null }:
+                        collection.Add(CreatePatchedFactoryDescriptor(descriptor));
+                        break;
+                    default:
+                        collection.Add(descriptor);
+                        break;
                 }
             }
 


### PR DESCRIPTION
The modification updates the conditional checks inside Transient Disposables service detection to include consideration for KeyedService. It now verifies whether a KeyedService exists, checking both ImplementationType and ImplementationFactory for each service offering, be it keyed or non-keyed.

Fixes https://github.com/dotnet/blazor-samples/issues/282