### PR TITLE
BlazorWebAppMovies/SeedData - DateOnly ctor instead of Parse()

### DIFF
--- a/8.0/BlazorWebAppMovies/Data/SeedData.cs
+++ b/8.0/BlazorWebAppMovies/Data/SeedData.cs
@@ -26,7 +26,7 @@ namespace BlazorWebAppMovies.Data
                 new Movie
                 {
                     Title = "Mad Max",
-                    ReleaseDate = DateOnly.Parse("1979-4-12"),
+                    ReleaseDate = new DateOnly(1979, 4, 12),
                     Genre = "Sci-fi (Cyberpunk)",
                     Price = 2.51M,
                     Rating = "R",
@@ -34,7 +34,7 @@ namespace BlazorWebAppMovies.Data
                 new Movie
                 {
                     Title = "The Road Warrior",
-                    ReleaseDate = DateOnly.Parse("1981-12-24"),
+                    ReleaseDate = new DateOnly(1981, 12, 24),
                     Genre = "Sci-fi (Cyberpunk)",
                     Price = 2.78M,
                     Rating = "R",
@@ -42,7 +42,7 @@ namespace BlazorWebAppMovies.Data
                 new Movie
                 {
                     Title = "Mad Max: Beyond Thunderdome",
-                    ReleaseDate = DateOnly.Parse("1985-7-10"),
+                    ReleaseDate = new DateOnly(1985, 7, 10),
                     Genre = "Sci-fi (Cyberpunk)",
                     Price = 3.55M,
                     Rating = "PG-13",
@@ -50,7 +50,7 @@ namespace BlazorWebAppMovies.Data
                 new Movie
                 {
                     Title = "Mad Max: Fury Road",
-                    ReleaseDate = DateOnly.Parse("2015-5-15"),
+                    ReleaseDate = new DateOnly(2015, 5, 15),
                     Genre = "Sci-fi (Cyberpunk)",
                     Price = 8.43M,
                     Rating = "R",
@@ -58,7 +58,7 @@ namespace BlazorWebAppMovies.Data
                 new Movie
                 {
                     Title = "Furiosa: A Mad Max Saga",
-                    ReleaseDate = DateOnly.Parse("2024-5-24"),
+                    ReleaseDate = new DateOnly(2024, 5, 24),
                     Genre = "Sci-fi (Cyberpunk)",
                     Price = 13.49M,
                     Rating = "R",


### PR DESCRIPTION
Parsing a constant literal seems odd to me.