### PR TITLE
Update FileUpload2.razor

### DIFF
--- a/8.0/BlazorSample_BlazorWebApp/Components/Pages/FileUpload2.razor
+++ b/8.0/BlazorSample_BlazorWebApp/Components/Pages/FileUpload2.razor
@@ -77,8 +77,10 @@
                 {
                     files.Add(new() { Name = file.Name });
 
-                    var fileContent = 
-                        new StreamContent(file.OpenReadStream(maxFileSize));
+                    await using var fileStream = uploadedFile.OpenReadStream(maxAllowedSize: maxFileSize);
+                    using var memoryStream = new MemoryStream();
+                    await fileStream.CopyToAsync(memoryStream);
+                    var fileContent = new ByteArrayContent(memoryStream.ToArray());
 
                     fileContent.Headers.ContentType = 
                         new MediaTypeHeaderValue(file.ContentType);


### PR DESCRIPTION
The older code doesn't work, when comes the upload, the stream is already closed and doesn't allow the upload.