### PR TITLE
CallJsExample7 - catch-throw removal

### DIFF
--- a/3.1/BlazorSample_Server/Pages/CallJsExample7.razor.cs
+++ b/3.1/BlazorSample_Server/Pages/CallJsExample7.razor.cs
@@ -18,14 +18,7 @@ namespace BlazorSample.Pages
 
             foreach (var subscription in subscriptions)
             {
-                try
-                {
-                    subscription.OnNext(title);
-                }
-                catch (Exception)
-                {
-                    throw;
-                }
+                subscription.OnNext(title);
             }
         }
 

--- a/3.1/BlazorSample_WebAssembly/Pages/CallJsExample7.razor.cs
+++ b/3.1/BlazorSample_WebAssembly/Pages/CallJsExample7.razor.cs
@@ -4,11 +4,11 @@ using Microsoft.AspNetCore.Components;
 
 namespace BlazorSample.Pages
 {
-    public partial class CallJsExample7 : 
+    public partial class CallJsExample7 :
         ComponentBase, IObservable<ElementReference>, IDisposable
     {
         private bool disposing;
-        private IList<IObserver<ElementReference>> subscriptions = 
+        private IList<IObserver<ElementReference>> subscriptions =
             new List<IObserver<ElementReference>>();
         private ElementReference title;
 
@@ -18,14 +18,7 @@ namespace BlazorSample.Pages
 
             foreach (var subscription in subscriptions)
             {
-                try
-                {
-                    subscription.OnNext(title);
-                }
-                catch (Exception)
-                {
-                    throw;
-                }
+                subscription.OnNext(title);
             }
         }
 
@@ -61,7 +54,7 @@ namespace BlazorSample.Pages
 
         private class Subscription : IDisposable
         {
-            public Subscription(IObserver<ElementReference> observer, 
+            public Subscription(IObserver<ElementReference> observer,
                 CallJsExample7 self)
             {
                 Observer = observer;

--- a/5.0/BlazorSample_Server/Pages/CallJsExample7.razor.cs
+++ b/5.0/BlazorSample_Server/Pages/CallJsExample7.razor.cs
@@ -4,11 +4,11 @@ using Microsoft.AspNetCore.Components;
 
 namespace BlazorSample.Pages
 {
-    public partial class CallJsExample7 : 
+    public partial class CallJsExample7 :
         ComponentBase, IObservable<ElementReference>, IDisposable
     {
         private bool disposing;
-        private IList<IObserver<ElementReference>> subscriptions = 
+        private IList<IObserver<ElementReference>> subscriptions =
             new List<IObserver<ElementReference>>();
         private ElementReference title;
 
@@ -18,14 +18,7 @@ namespace BlazorSample.Pages
 
             foreach (var subscription in subscriptions)
             {
-                try
-                {
-                    subscription.OnNext(title);
-                }
-                catch (Exception)
-                {
-                    throw;
-                }
+                subscription.OnNext(title);
             }
         }
 
@@ -61,7 +54,7 @@ namespace BlazorSample.Pages
 
         private class Subscription : IDisposable
         {
-            public Subscription(IObserver<ElementReference> observer, 
+            public Subscription(IObserver<ElementReference> observer,
                 CallJsExample7 self)
             {
                 Observer = observer;

--- a/5.0/BlazorSample_WebAssembly/Pages/CallJsExample7.razor.cs
+++ b/5.0/BlazorSample_WebAssembly/Pages/CallJsExample7.razor.cs
@@ -4,11 +4,11 @@ using Microsoft.AspNetCore.Components;
 
 namespace BlazorSample.Pages
 {
-    public partial class CallJsExample7 : 
+    public partial class CallJsExample7 :
         ComponentBase, IObservable<ElementReference>, IDisposable
     {
         private bool disposing;
-        private IList<IObserver<ElementReference>> subscriptions = 
+        private IList<IObserver<ElementReference>> subscriptions =
             new List<IObserver<ElementReference>>();
         private ElementReference title;
 
@@ -18,14 +18,7 @@ namespace BlazorSample.Pages
 
             foreach (var subscription in subscriptions)
             {
-                try
-                {
-                    subscription.OnNext(title);
-                }
-                catch (Exception)
-                {
-                    throw;
-                }
+                subscription.OnNext(title);
             }
         }
 
@@ -61,7 +54,7 @@ namespace BlazorSample.Pages
 
         private class Subscription : IDisposable
         {
-            public Subscription(IObserver<ElementReference> observer, 
+            public Subscription(IObserver<ElementReference> observer,
                 CallJsExample7 self)
             {
                 Observer = observer;

--- a/6.0/BlazorSample_Server/Pages/CallJsExample7.razor.cs
+++ b/6.0/BlazorSample_Server/Pages/CallJsExample7.razor.cs
@@ -4,11 +4,11 @@ using Microsoft.AspNetCore.Components;
 
 namespace BlazorSample.Pages;
 
-public partial class CallJsExample7 : 
+public partial class CallJsExample7 :
     ComponentBase, IObservable<ElementReference>, IDisposable
 {
     private bool disposing;
-    private IList<IObserver<ElementReference>> subscriptions = 
+    private IList<IObserver<ElementReference>> subscriptions =
         new List<IObserver<ElementReference>>();
     private ElementReference title;
 
@@ -18,14 +18,7 @@ public partial class CallJsExample7 :
 
         foreach (var subscription in subscriptions)
         {
-            try
-            {
-                subscription.OnNext(title);
-            }
-            catch (Exception)
-            {
-                throw;
-            }
+            subscription.OnNext(title);
         }
     }
 
@@ -61,7 +54,7 @@ public partial class CallJsExample7 :
 
     private class Subscription : IDisposable
     {
-        public Subscription(IObserver<ElementReference> observer, 
+        public Subscription(IObserver<ElementReference> observer,
             CallJsExample7 self)
         {
             Observer = observer;

--- a/6.0/BlazorSample_WebAssembly/Pages/CallJsExample7.razor.cs
+++ b/6.0/BlazorSample_WebAssembly/Pages/CallJsExample7.razor.cs
@@ -4,11 +4,11 @@ using Microsoft.AspNetCore.Components;
 
 namespace BlazorSample.Pages;
 
-public partial class CallJsExample7 : 
+public partial class CallJsExample7 :
     ComponentBase, IObservable<ElementReference>, IDisposable
 {
     private bool disposing;
-    private IList<IObserver<ElementReference>> subscriptions = 
+    private IList<IObserver<ElementReference>> subscriptions =
         new List<IObserver<ElementReference>>();
     private ElementReference title;
 
@@ -18,14 +18,7 @@ public partial class CallJsExample7 :
 
         foreach (var subscription in subscriptions)
         {
-            try
-            {
-                subscription.OnNext(title);
-            }
-            catch (Exception)
-            {
-                throw;
-            }
+            subscription.OnNext(title);
         }
     }
 
@@ -61,7 +54,7 @@ public partial class CallJsExample7 :
 
     private class Subscription : IDisposable
     {
-        public Subscription(IObserver<ElementReference> observer, 
+        public Subscription(IObserver<ElementReference> observer,
             CallJsExample7 self)
         {
             Observer = observer;

--- a/7.0/BlazorSample_Server/Pages/CallJsExample7.razor.cs
+++ b/7.0/BlazorSample_Server/Pages/CallJsExample7.razor.cs
@@ -4,11 +4,11 @@ using Microsoft.AspNetCore.Components;
 
 namespace BlazorSample.Pages;
 
-public partial class CallJsExample7 : 
+public partial class CallJsExample7 :
     ComponentBase, IObservable<ElementReference>, IDisposable
 {
     private bool disposing;
-    private IList<IObserver<ElementReference>> subscriptions = 
+    private IList<IObserver<ElementReference>> subscriptions =
         new List<IObserver<ElementReference>>();
     private ElementReference title;
 
@@ -18,14 +18,7 @@ public partial class CallJsExample7 :
 
         foreach (var subscription in subscriptions)
         {
-            try
-            {
-                subscription.OnNext(title);
-            }
-            catch (Exception)
-            {
-                throw;
-            }
+            subscription.OnNext(title);
         }
     }
 
@@ -61,7 +54,7 @@ public partial class CallJsExample7 :
 
     private class Subscription : IDisposable
     {
-        public Subscription(IObserver<ElementReference> observer, 
+        public Subscription(IObserver<ElementReference> observer,
             CallJsExample7 self)
         {
             Observer = observer;

--- a/7.0/BlazorSample_WebAssembly/Pages/CallJsExample7.razor.cs
+++ b/7.0/BlazorSample_WebAssembly/Pages/CallJsExample7.razor.cs
@@ -4,11 +4,11 @@ using Microsoft.AspNetCore.Components;
 
 namespace BlazorSample.Pages;
 
-public partial class CallJsExample7 : 
+public partial class CallJsExample7 :
     ComponentBase, IObservable<ElementReference>, IDisposable
 {
     private bool disposing;
-    private IList<IObserver<ElementReference>> subscriptions = 
+    private IList<IObserver<ElementReference>> subscriptions =
         new List<IObserver<ElementReference>>();
     private ElementReference title;
 
@@ -18,14 +18,7 @@ public partial class CallJsExample7 :
 
         foreach (var subscription in subscriptions)
         {
-            try
-            {
-                subscription.OnNext(title);
-            }
-            catch (Exception)
-            {
-                throw;
-            }
+            subscription.OnNext(title);
         }
     }
 
@@ -61,7 +54,7 @@ public partial class CallJsExample7 :
 
     private class Subscription : IDisposable
     {
-        public Subscription(IObserver<ElementReference> observer, 
+        public Subscription(IObserver<ElementReference> observer,
             CallJsExample7 self)
         {
             Observer = observer;

--- a/8.0/BlazorSample_BlazorWebApp/Components/Pages/CallJs7.razor.cs
+++ b/8.0/BlazorSample_BlazorWebApp/Components/Pages/CallJs7.razor.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace BlazorSample.Components.Pages;
 
-public partial class CallJs7 : 
+public partial class CallJs7 :
     ComponentBase, IObservable<ElementReference>, IDisposable
 {
     private bool disposing;
@@ -15,14 +15,7 @@ public partial class CallJs7 :
 
         foreach (var subscription in subscriptions)
         {
-            try
-            {
-                subscription.OnNext(title);
-            }
-            catch (Exception)
-            {
-                throw;
-            }
+            subscription.OnNext(title);
         }
     }
 

--- a/8.0/BlazorSample_WebAssembly/Pages/CallJs7.razor.cs
+++ b/8.0/BlazorSample_WebAssembly/Pages/CallJs7.razor.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace BlazorSample.Pages;
 
-public partial class CallJs7 : 
+public partial class CallJs7 :
     ComponentBase, IObservable<ElementReference>, IDisposable
 {
     private bool disposing;
@@ -15,14 +15,7 @@ public partial class CallJs7 :
 
         foreach (var subscription in subscriptions)
         {
-            try
-            {
-                subscription.OnNext(title);
-            }
-            catch (Exception)
-            {
-                throw;
-            }
+            subscription.OnNext(title);
         }
     }
 


### PR DESCRIPTION
This `catch` statement just rethrows the exception and doesn't add any value to the sample.

(Maybe I would also update the other try-catch in the `Dispose()` method. The usual convention is to add a `// NOOP` comment in an empty `catch` statement to explicitly indicate the intent to ignore the exception.)

If you approve this PR, I will create a PR to aspnetdoc repo to pull the updated sample there.