### PR TITLE
CallJsExample8.razor - AsTask() removed

### DIFF
--- a/5.0/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample8.razor
+++ b/5.0/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample8.razor
@@ -28,7 +28,7 @@
 
     private async Task ShowAsync(double latitude, double longitude)
         => await mapModule.InvokeVoidAsync("setMapCenter", mapInstance, latitude,
-            longitude).AsTask();
+            longitude);
 
     async ValueTask IAsyncDisposable.DisposeAsync()
     {

--- a/5.0/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample8.razor
+++ b/5.0/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample8.razor
@@ -28,7 +28,7 @@
 
     private async Task ShowAsync(double latitude, double longitude)
         => await mapModule.InvokeVoidAsync("setMapCenter", mapInstance, latitude, 
-            longitude).AsTask();
+            longitude);
 
     async ValueTask IAsyncDisposable.DisposeAsync()
     {

--- a/6.0/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample8.razor
+++ b/6.0/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample8.razor
@@ -31,7 +31,7 @@
         if (mapModule is not null && mapInstance is not null)
         {
             await mapModule.InvokeVoidAsync("setMapCenter", mapInstance, 
-                latitude, longitude).AsTask();
+                latitude, longitude);
         }
     }
 

--- a/6.0/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample8.razor
+++ b/6.0/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample8.razor
@@ -31,7 +31,7 @@
         if (mapModule is not null && mapInstance is not null)
         {
             await mapModule.InvokeVoidAsync("setMapCenter", mapInstance, 
-                latitude, longitude).AsTask();
+                latitude, longitude);
         }
     }
 

--- a/7.0/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample8.razor
+++ b/7.0/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample8.razor
@@ -31,7 +31,7 @@
         if (mapModule is not null && mapInstance is not null)
         {
             await mapModule.InvokeVoidAsync("setMapCenter", mapInstance, 
-                latitude, longitude).AsTask();
+                latitude, longitude);
         }
     }
 

--- a/7.0/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample8.razor
+++ b/7.0/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample8.razor
@@ -31,7 +31,7 @@
         if (mapModule is not null && mapInstance is not null)
         {
             await mapModule.InvokeVoidAsync("setMapCenter", mapInstance, 
-                latitude, longitude).AsTask();
+                latitude, longitude);
         }
     }
 

--- a/8.0/BlazorSample_BlazorWebApp/Components/Pages/CallJs8.razor
+++ b/8.0/BlazorSample_BlazorWebApp/Components/Pages/CallJs8.razor
@@ -38,7 +38,7 @@
         if (mapModule is not null && mapInstance is not null)
         {
             await mapModule.InvokeVoidAsync("setMapCenter", mapInstance, 
-                latitude, longitude).AsTask();
+                latitude, longitude);
         }
     }
 

--- a/8.0/BlazorSample_WebAssembly/Pages/CallJs8.razor
+++ b/8.0/BlazorSample_WebAssembly/Pages/CallJs8.razor
@@ -38,7 +38,7 @@
         if (mapModule is not null && mapInstance is not null)
         {
             await mapModule.InvokeVoidAsync("setMapCenter", mapInstance, 
-                latitude, longitude).AsTask();
+                latitude, longitude);
         }
     }
 


### PR DESCRIPTION
I think the `.AsTask()` call doesn't add any value here (it would have been needed if there was a `return` instead of `await`).  
cc @guardrex