### PR TITLE
Add back 'razor' as a code language

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ name: "Blazor sample applications"
 products:
 - aspnet-core
 - blazor
-urlFragment: "blazor-samples"
+urlFragment: "/"
 ---
 # Samples to accompany the official Microsoft Blazor documentation
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 description: "Samples to accompany the official Microsoft Blazor documentation."
 page_type: sample
 languages:
+- razor
 - csharp
 - cshtml
 name: "Blazor sample applications"


### PR DESCRIPTION
Hi Jon ... 👋 Hope ur well!!! ... and *Happy New Year!* 🍾

A few years ago, we had to remove `razor` from the code languages on https://github.com/dotnet/blazor-samples/pull/21. You said that you'd request it be added. Can we add `razor` back?

Also, it seems like the `urlFragment` should be `/` instead of `/blazor-samples` because the link to the sample browser ends up ...

```
https://learn.microsoft.com/en-us/samples/dotnet/blazor-samples/blazor-samples/
```

Let me know if that's going to break 💥, and I'll revert. 👂 

........ and ***one other ❓*** ... there's obviously a delay between when I update the README on this repo and when the MS samples page grabs that README's content for display. Do you know how long that delay is? ... just curious.