### PR TITLE
Improvements to Xref Generator

### DIFF
--- a/BlazorWebAssemblyXrefGenerator/Pages/Home.razor
+++ b/BlazorWebAssemblyXrefGenerator/Pages/Home.razor
@@ -28,7 +28,7 @@
                         </div>
                         <div class="form-group">
                             <button type="submit" class="btn btn-primary">Search</button>
-                            <button type="button" class="btn btn-secondary" onclick="document.getElementById('searchText').value=''">Clear</button>
+                            <button type="button" class="btn btn-secondary" @onclick="() => ClearUI(clearSearchText: true)">Clear</button>
                         </div>
                     </div>
                 </div>
@@ -128,6 +128,12 @@
 
     public async Task GetSearchResults()
     {
+        // If the first result is not empty then we will clear the UI
+        if (!string.IsNullOrEmpty(apiResult1.DisplayName))
+        {
+            await ClearUI();
+        }
+
         message = string.Empty;
         var apiClient = ClientFactory.CreateClient("APIClient");
 
@@ -150,9 +156,8 @@
             return;
         }
 
-        if (SearchResultItems?.Results != null)
+        if (SearchResultItems?.Results?.Any() == true)
         {
-            await ClearUI();
             var index = 0;
             var proxyClient = ClientFactory.CreateClient("ProxyClient");
 
@@ -260,8 +265,13 @@
         }
     }
 
-    private async Task ClearUI()
+    private async Task ClearUI(bool clearSearchText = false)
     {
+        if (clearSearchText)
+        {
+            Model!.SearchText = string.Empty;    
+        }
+
         var dictionary = new Dictionary<string, object?>
         {
             { "DisplayName", string.Empty },

--- a/BlazorWebAssemblyXrefGenerator/Pages/Home.razor
+++ b/BlazorWebAssemblyXrefGenerator/Pages/Home.razor
@@ -28,7 +28,7 @@
                         </div>
                         <div class="form-group">
                             <button type="submit" class="btn btn-primary">Search</button>
-                            <button type="button" class="btn btn-secondary" @onclick="() => ClearUI(clearSearchText: true)">Clear</button>
+                            <button type="button" class="btn btn-secondary" @onclick="() => ClearUI(clearEverything: true)">Clear</button>
                         </div>
                     </div>
                 </div>
@@ -265,11 +265,12 @@
         }
     }
 
-    private async Task ClearUI(bool clearSearchText = false)
+    private async Task ClearUI(bool clearEverything = false)
     {
-        if (clearSearchText)
+        if (clearEverything)
         {
-            Model!.SearchText = string.Empty;    
+            Model!.SearchText = string.Empty;
+            message = string.Empty;
         }
 
         var dictionary = new Dictionary<string, object?>

--- a/BlazorWebAssemblyXrefGenerator/Pages/Home.razor
+++ b/BlazorWebAssemblyXrefGenerator/Pages/Home.razor
@@ -154,15 +154,13 @@
         {
             await ClearUI();
             var index = 0;
+            var proxyClient = ClientFactory.CreateClient("ProxyClient");
 
             foreach (var result in SearchResultItems.Results)
             {
                 index++;
 
-                var client = ClientFactory.CreateClient();
-                var urlEncodedRequestUrl = WebUtility.UrlEncode($"https://learn.microsoft.com/en-us{result.Url}?view={dotNetVersion}");
-                var request = new HttpRequestMessage(HttpMethod.Get, $"https://corsproxy.io/?{urlEncodedRequestUrl}");
-                var apiBrowserPage = await client.SendAsync(request);
+                var apiBrowserPage = await proxyClient.GetAsync($"?https://learn.microsoft.com/en-us{result.Url}?view={dotNetVersion}");
                 var metaTag = new Regex("<meta name=\"ms.assetid\" content=\"(.+?)\" />");
                 var match = metaTag.Match(await apiBrowserPage.Content.ReadAsStringAsync()).Groups[1].Value;
                 result.Link = match.Replace("*", "%2A").Replace("`", "%60");

--- a/BlazorWebAssemblyXrefGenerator/Program.cs
+++ b/BlazorWebAssemblyXrefGenerator/Program.cs
@@ -10,6 +10,6 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.
 
 builder.Services.AddHttpClient("APIClient", client => client.BaseAddress = new Uri("https://learn.microsoft.com"));
 
-builder.Services.AddHttpClient("APIBrowserPageClient", client => client.BaseAddress = new Uri("https://learn.microsoft.com/en-us"));
+builder.Services.AddHttpClient("ProxyClient", client => client.BaseAddress = new Uri("https://corsproxy.io"));
 
 await builder.Build().RunAsync();


### PR DESCRIPTION
When trying out the Xref Generator I spotted the following things
* Clear button only cleared the search text, not the results on the screen
* When searching for an item with no results there was no message displayed
* When searching for an item with no results after getting previous results the previous results stayed on the screen

I had a peek through the code and made the following changes
* Updated the unused registered `APIBrowserPageClient` to `ProxyClient` to allow for use in code
* Only register `ProxyClient` once before using it to get each result
* `SearchResultItems?.Results` was never null from the first request so the `No results returned.` message was not getting displayed when searching for something with no results . This has been updated to `if (SearchResultItems?.Results?.Any() == true)` which will check if it is not `null` and if there are any results to correctly display the message when required.
* If the first api result is not empty we will now clear the UI to accurately display any messages.
* Use the ClearUI method in the clear button, amending it to allow for clearing all required fields in this scenario.

There are some other improvements I want to look at making surrounding duplication of the results but this was all I had time for at the moment.