### PR TITLE
Convert to C# configuration

### DIFF
--- a/9.0/BlazorWebAppEntra/BlazorWebAppEntra/Program.cs
+++ b/9.0/BlazorWebAppEntra/BlazorWebAppEntra/Program.cs
@@ -16,9 +16,21 @@ builder.Services.AddRazorComponents()
     .AddAuthenticationStateSerialization(options => options.SerializeAllClaims = true);
 
 builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
-    .AddMicrosoftIdentityWebApp(builder.Configuration.GetSection("AzureAd"))
+    .AddMicrosoftIdentityWebApp(msIdentityOptions =>
+    {
+        msIdentityOptions.CallbackPath = "/signin-oidc";
+        msIdentityOptions.ClientId = "{CLIENT ID (BLAZOR APP)}";
+        msIdentityOptions.Domain = "{DIRECTORY NAME}.onmicrosoft.com";
+        msIdentityOptions.Instance = "https://login.microsoftonline.com/";
+        msIdentityOptions.ResponseType = "code";
+        msIdentityOptions.TenantId = "{TENANT ID}";
+    })
     .EnableTokenAcquisitionToCallDownstreamApi()
-    .AddDownstreamApi("DownstreamApi", builder.Configuration.GetSection("DownstreamApi"))
+    .AddDownstreamApi("DownstreamApi", configOptions =>
+    {
+        configOptions.BaseUrl = "{BASE URL}";
+        configOptions.Scopes = [ "{APP ID URI}/Weather.Get" ];
+    })
     .AddInMemoryTokenCaches();
 
 builder.Services.AddAuthorization();

--- a/9.0/BlazorWebAppEntra/BlazorWebAppEntra/appsettings.json
+++ b/9.0/BlazorWebAppEntra/BlazorWebAppEntra/appsettings.json
@@ -1,26 +1,9 @@
 {
-  /*
-  The following identity settings need to be configured
-  before the project can be successfully executed.
-  For more info see https://aka.ms/dotnet-template-ms-identity-platform 
-  */
-  "AzureAd": {
-    "CallbackPath": "/signin-oidc",
-    "ClientId": "{CLIENT ID}",
-    "Domain": "{TENANT DOMAIN}",
-    "Instance": "https://login.microsoftonline.com/",
-    "ResponseType": "code",
-    "TenantId": "{TENANT ID}"
-  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "DownstreamApi": {
-    "BaseUrl": "{BASE ADDRESS}",
-    "Scopes": [ "{APP ID URI}/{SCOPE NAME}" ]
-  }
+  "AllowedHosts": "*"
 }

--- a/9.0/BlazorWebAppEntraBff/BlazorWebAppEntra/Program.cs
+++ b/9.0/BlazorWebAppEntraBff/BlazorWebAppEntra/Program.cs
@@ -13,9 +13,21 @@ builder.AddServiceDefaults();
 
 // Add services to the container.
 builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
-    .AddMicrosoftIdentityWebApp(builder.Configuration.GetSection("AzureAd"))
+    .AddMicrosoftIdentityWebApp(msIdentityOptions =>
+    {
+        msIdentityOptions.CallbackPath = "/signin-oidc";
+        msIdentityOptions.ClientId = "{CLIENT ID (BLAZOR APP)}";
+        msIdentityOptions.Domain = "{DIRECTORY NAME}.onmicrosoft.com";
+        msIdentityOptions.Instance = "https://login.microsoftonline.com/";
+        msIdentityOptions.ResponseType = "code";
+        msIdentityOptions.TenantId = "{TENANT ID}";
+    })
     .EnableTokenAcquisitionToCallDownstreamApi()
-    .AddDownstreamApi("DownstreamApi", builder.Configuration.GetSection("DownstreamApi"))
+    .AddDownstreamApi("DownstreamApi", configOptions =>
+    {
+        configOptions.BaseUrl = "{BASE URL}";
+        configOptions.Scopes = [ "{APP ID URI}/Weather.Get" ];
+    })
     .AddInMemoryTokenCaches();
 
 builder.Services.AddOptions<OpenIdConnectOptions>(OpenIdConnectDefaults.AuthenticationScheme).Configure(oidcOptions =>

--- a/9.0/BlazorWebAppEntraBff/BlazorWebAppEntra/appsettings.json
+++ b/9.0/BlazorWebAppEntraBff/BlazorWebAppEntra/appsettings.json
@@ -1,21 +1,9 @@
 {
-  "AzureAd": {
-    "CallbackPath": "/signin-oidc",
-    "ClientId": "{CLIENT ID}",
-    "Domain": "{TENANT DOMAIN}",
-    "Instance": "https://login.microsoftonline.com/",
-    "ResponseType": "code",
-    "TenantId": "{TENANT ID}"
-  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*",
-  "DownstreamApi": {
-    "BaseUrl": "{BASE ADDRESS}",
-    "Scopes": [ "{APP ID URI}/{SCOPE}" ]
-  }
+  "AllowedHosts": "*"
 }


### PR DESCRIPTION
Fixes #533

Per offline discussion, we're converting to C# configuration to help new-to-.NET devs with discovery of configuration settings via C# autocompletion. A new section will be added to the BWA+Entra article on how to configure the samples via the JSON config provider (app settings) on https://github.com/dotnet/AspNetCore.Docs/issues/35377.