### PR TITLE
Update Swashbuckle link

### DIFF
--- a/9.0/MauiBlazorWebIdentity/MauiBlazorWeb/MauiBlazorWeb.Web/Program.cs
+++ b/9.0/MauiBlazorWebIdentity/MauiBlazorWeb/MauiBlazorWeb.Web/Program.cs
@@ -41,7 +41,8 @@ builder.Services.AddIdentityApiEndpoints<ApplicationUser>(options => options.Sig
 
 builder.Services.AddSingleton<IEmailSender<ApplicationUser>, IdentityNoOpEmailSender>();
 
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+// Learn more about configuring Swagger/OpenAPI at 
+// https://learn.microsoft.com/aspnet/core/tutorials/getting-started-with-swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 


### PR DESCRIPTION
Fixes #561

Thanks @DevTKSS! 🚀 

cc: @BethMassi ... Recommend that you change the underlying link for `https://aka.ms/aspnetcore/swashbuckle` to not point at the 8.0 version of the article. At least for now, my fix is merely to place the absolute URL of the doc here without an article version.