### PR TITLE
Fix ASCII diagram

### DIFF
--- a/10.0/DotNetOnWebWorkers/README.md
+++ b/10.0/DotNetOnWebWorkers/README.md
@@ -49,6 +49,7 @@ From `react` to `dotnet`: QR code generation request.
 
 From `dotnet` to `react`: Populating a frontend element with data.
 
+```
 +-----------------------------------------------+              +---------------------+
 | React App                                     |              | WASM App            |
 | (Main Thread)                                 |              | (WebWorker Thread)  |
@@ -67,3 +68,4 @@ From `dotnet` to `react`: Populating a frontend element with data.
 ||+--------------+ |          | +-------------+||              | |                  ||
 |+-----------------+          +----------------+|              | +------------------+|
 +-----------------------------------------------+              +---------------------+
+```


### PR DESCRIPTION
Fixed display of the diagram illustrating the interaction between React and WASM apps. It was missing the markdown code block.