### PR TITLE
Fix broken link to learn.microsoft.com for DotNetOnWebWorkersBlazorWebAssembly

### DIFF
--- a/10.0/DotNetOnWebWorkersBlazorWebAssembly/README.md
+++ b/10.0/DotNetOnWebWorkersBlazorWebAssembly/README.md
@@ -1,6 +1,6 @@
 # .NET on Web Workers - Blazor WebAssembly (`DotNetOnWebWorkersBlazorWebAssembly`)
 
-This sample accompanies [ASP.NET Core Blazor with .NET on Web Workers](https://learn.microsoft.com/aspnet/core/blazor/blazor-on-dotnet-with-web-workers) in the ASP.NET Core Blazor documentation.
+This sample accompanies [ASP.NET Core Blazor with .NET on Web Workers](https://learn.microsoft.com/en-us/aspnet/core/blazor/blazor-with-dotnet-on-web-workers) in the ASP.NET Core Blazor documentation.
 
 # Startup
 

--- a/10.0/DotNetOnWebWorkersBlazorWebAssembly/README.md
+++ b/10.0/DotNetOnWebWorkersBlazorWebAssembly/README.md
@@ -1,6 +1,6 @@
 # .NET on Web Workers - Blazor WebAssembly (`DotNetOnWebWorkersBlazorWebAssembly`)
 
-This sample accompanies [ASP.NET Core Blazor with .NET on Web Workers](https://learn.microsoft.com/en-us/aspnet/core/blazor/blazor-with-dotnet-on-web-workers) in the ASP.NET Core Blazor documentation.
+This sample accompanies [ASP.NET Core Blazor with .NET on Web Workers](https://learn.microsoft.com/aspnet/core/blazor/blazor-with-dotnet-on-web-workers) in the ASP.NET Core Blazor documentation.
 
 # Startup
 


### PR DESCRIPTION
Fixed the broken link to the "ASP.NET Core Blazor with .NET on Web Workers" article on learn.microsoft.com.